### PR TITLE
chore: Migrate dialogflow synth.py to bazel

### DIFF
--- a/grpc-google-cloud-dialogflow-v2/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dialogflow-v2/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.0.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/dialogflow/v2/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/AgentsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/AgentsGrpc.java
@@ -52,7 +52,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/agent.proto")
 public final class AgentsGrpc {
 
@@ -61,26 +61,18 @@ public final class AgentsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.Agents";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
-      METHOD_GET_AGENT = getGetAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
       getGetAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAgent",
+      requestType = com.google.cloud.dialogflow.v2.GetAgentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Agent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
       getGetAgentMethod() {
-    return getGetAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
-      getGetAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
         getGetAgentMethod;
@@ -94,8 +86,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2.Agent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.dialogflow.v2.Agents", "GetAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -111,26 +102,18 @@ public final class AgentsGrpc {
     return getGetAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.SetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
-      METHOD_SET_AGENT = getSetAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.SetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
       getSetAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetAgent",
+      requestType = com.google.cloud.dialogflow.v2.SetAgentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Agent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.SetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
       getSetAgentMethod() {
-    return getSetAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.SetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
-      getSetAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.SetAgentRequest, com.google.cloud.dialogflow.v2.Agent>
         getSetAgentMethod;
@@ -144,8 +127,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2.Agent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.dialogflow.v2.Agents", "SetAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -161,26 +143,18 @@ public final class AgentsGrpc {
     return getSetAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_AGENT = getDeleteAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>
       getDeleteAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAgent",
+      requestType = com.google.cloud.dialogflow.v2.DeleteAgentRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>
       getDeleteAgentMethod() {
-    return getDeleteAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>
-      getDeleteAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>
         getDeleteAgentMethod;
@@ -194,9 +168,7 @@ public final class AgentsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "DeleteAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -213,30 +185,20 @@ public final class AgentsGrpc {
     return getDeleteAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSearchAgentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.SearchAgentsRequest,
-          com.google.cloud.dialogflow.v2.SearchAgentsResponse>
-      METHOD_SEARCH_AGENTS = getSearchAgentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.SearchAgentsRequest,
           com.google.cloud.dialogflow.v2.SearchAgentsResponse>
       getSearchAgentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SearchAgents",
+      requestType = com.google.cloud.dialogflow.v2.SearchAgentsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.SearchAgentsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.SearchAgentsRequest,
           com.google.cloud.dialogflow.v2.SearchAgentsResponse>
       getSearchAgentsMethod() {
-    return getSearchAgentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.SearchAgentsRequest,
-          com.google.cloud.dialogflow.v2.SearchAgentsResponse>
-      getSearchAgentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.SearchAgentsRequest,
             com.google.cloud.dialogflow.v2.SearchAgentsResponse>
@@ -251,9 +213,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2.SearchAgentsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "SearchAgents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SearchAgents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -271,26 +231,18 @@ public final class AgentsGrpc {
     return getSearchAgentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTrainAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.TrainAgentRequest, com.google.longrunning.Operation>
-      METHOD_TRAIN_AGENT = getTrainAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.TrainAgentRequest, com.google.longrunning.Operation>
       getTrainAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TrainAgent",
+      requestType = com.google.cloud.dialogflow.v2.TrainAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.TrainAgentRequest, com.google.longrunning.Operation>
       getTrainAgentMethod() {
-    return getTrainAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.TrainAgentRequest, com.google.longrunning.Operation>
-      getTrainAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.TrainAgentRequest, com.google.longrunning.Operation>
         getTrainAgentMethod;
@@ -304,8 +256,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.dialogflow.v2.Agents", "TrainAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TrainAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -322,26 +273,18 @@ public final class AgentsGrpc {
     return getTrainAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ExportAgentRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_AGENT = getExportAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ExportAgentRequest, com.google.longrunning.Operation>
       getExportAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportAgent",
+      requestType = com.google.cloud.dialogflow.v2.ExportAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ExportAgentRequest, com.google.longrunning.Operation>
       getExportAgentMethod() {
-    return getExportAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ExportAgentRequest, com.google.longrunning.Operation>
-      getExportAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ExportAgentRequest, com.google.longrunning.Operation>
         getExportAgentMethod;
@@ -355,9 +298,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "ExportAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -374,26 +315,18 @@ public final class AgentsGrpc {
     return getExportAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ImportAgentRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_AGENT = getImportAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ImportAgentRequest, com.google.longrunning.Operation>
       getImportAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportAgent",
+      requestType = com.google.cloud.dialogflow.v2.ImportAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ImportAgentRequest, com.google.longrunning.Operation>
       getImportAgentMethod() {
-    return getImportAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ImportAgentRequest, com.google.longrunning.Operation>
-      getImportAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ImportAgentRequest, com.google.longrunning.Operation>
         getImportAgentMethod;
@@ -407,9 +340,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "ImportAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -426,26 +357,18 @@ public final class AgentsGrpc {
     return getImportAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRestoreAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.RestoreAgentRequest, com.google.longrunning.Operation>
-      METHOD_RESTORE_AGENT = getRestoreAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.RestoreAgentRequest, com.google.longrunning.Operation>
       getRestoreAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RestoreAgent",
+      requestType = com.google.cloud.dialogflow.v2.RestoreAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.RestoreAgentRequest, com.google.longrunning.Operation>
       getRestoreAgentMethod() {
-    return getRestoreAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.RestoreAgentRequest, com.google.longrunning.Operation>
-      getRestoreAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.RestoreAgentRequest, com.google.longrunning.Operation>
         getRestoreAgentMethod;
@@ -459,9 +382,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "RestoreAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RestoreAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -478,30 +399,20 @@ public final class AgentsGrpc {
     return getRestoreAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetValidationResultMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetValidationResultRequest,
-          com.google.cloud.dialogflow.v2.ValidationResult>
-      METHOD_GET_VALIDATION_RESULT = getGetValidationResultMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetValidationResultRequest,
           com.google.cloud.dialogflow.v2.ValidationResult>
       getGetValidationResultMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetValidationResult",
+      requestType = com.google.cloud.dialogflow.v2.GetValidationResultRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.ValidationResult.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetValidationResultRequest,
           com.google.cloud.dialogflow.v2.ValidationResult>
       getGetValidationResultMethod() {
-    return getGetValidationResultMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetValidationResultRequest,
-          com.google.cloud.dialogflow.v2.ValidationResult>
-      getGetValidationResultMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetValidationResultRequest,
             com.google.cloud.dialogflow.v2.ValidationResult>
@@ -517,8 +428,7 @@ public final class AgentsGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Agents", "GetValidationResult"))
+                          generateFullMethodName(SERVICE_NAME, "GetValidationResult"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -538,19 +448,42 @@ public final class AgentsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AgentsStub newStub(io.grpc.Channel channel) {
-    return new AgentsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsStub>() {
+          @java.lang.Override
+          public AgentsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsStub(channel, callOptions);
+          }
+        };
+    return AgentsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AgentsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AgentsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsBlockingStub>() {
+          @java.lang.Override
+          public AgentsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsBlockingStub(channel, callOptions);
+          }
+        };
+    return AgentsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AgentsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AgentsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsFutureStub>() {
+          @java.lang.Override
+          public AgentsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsFutureStub(channel, callOptions);
+          }
+        };
+    return AgentsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -594,7 +527,7 @@ public final class AgentsGrpc {
     public void getAgent(
         com.google.cloud.dialogflow.v2.GetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Agent> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAgentMethod(), responseObserver);
     }
 
     /**
@@ -607,7 +540,7 @@ public final class AgentsGrpc {
     public void setAgent(
         com.google.cloud.dialogflow.v2.SetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Agent> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetAgentMethod(), responseObserver);
     }
 
     /**
@@ -620,7 +553,7 @@ public final class AgentsGrpc {
     public void deleteAgent(
         com.google.cloud.dialogflow.v2.DeleteAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAgentMethod(), responseObserver);
     }
 
     /**
@@ -639,7 +572,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.SearchAgentsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SearchAgentsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSearchAgentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSearchAgentsMethod(), responseObserver);
     }
 
     /**
@@ -653,7 +586,7 @@ public final class AgentsGrpc {
     public void trainAgent(
         com.google.cloud.dialogflow.v2.TrainAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getTrainAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTrainAgentMethod(), responseObserver);
     }
 
     /**
@@ -667,7 +600,7 @@ public final class AgentsGrpc {
     public void exportAgent(
         com.google.cloud.dialogflow.v2.ExportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportAgentMethod(), responseObserver);
     }
 
     /**
@@ -684,7 +617,7 @@ public final class AgentsGrpc {
     public void importAgent(
         com.google.cloud.dialogflow.v2.ImportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportAgentMethod(), responseObserver);
     }
 
     /**
@@ -700,7 +633,7 @@ public final class AgentsGrpc {
     public void restoreAgent(
         com.google.cloud.dialogflow.v2.RestoreAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getRestoreAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRestoreAgentMethod(), responseObserver);
     }
 
     /**
@@ -715,63 +648,63 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.GetValidationResultRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ValidationResult>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetValidationResultMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetValidationResultMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getGetAgentMethodHelper(),
+              getGetAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetAgentRequest,
                       com.google.cloud.dialogflow.v2.Agent>(this, METHODID_GET_AGENT)))
           .addMethod(
-              getSetAgentMethodHelper(),
+              getSetAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.SetAgentRequest,
                       com.google.cloud.dialogflow.v2.Agent>(this, METHODID_SET_AGENT)))
           .addMethod(
-              getDeleteAgentMethodHelper(),
+              getDeleteAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteAgentRequest, com.google.protobuf.Empty>(
                       this, METHODID_DELETE_AGENT)))
           .addMethod(
-              getSearchAgentsMethodHelper(),
+              getSearchAgentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.SearchAgentsRequest,
                       com.google.cloud.dialogflow.v2.SearchAgentsResponse>(
                       this, METHODID_SEARCH_AGENTS)))
           .addMethod(
-              getTrainAgentMethodHelper(),
+              getTrainAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.TrainAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_TRAIN_AGENT)))
           .addMethod(
-              getExportAgentMethodHelper(),
+              getExportAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ExportAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_AGENT)))
           .addMethod(
-              getImportAgentMethodHelper(),
+              getImportAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ImportAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_AGENT)))
           .addMethod(
-              getRestoreAgentMethodHelper(),
+              getRestoreAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.RestoreAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_RESTORE_AGENT)))
           .addMethod(
-              getGetValidationResultMethodHelper(),
+              getGetValidationResultMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetValidationResultRequest,
@@ -810,11 +743,7 @@ public final class AgentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
    * </pre>
    */
-  public static final class AgentsStub extends io.grpc.stub.AbstractStub<AgentsStub> {
-    private AgentsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AgentsStub extends io.grpc.stub.AbstractAsyncStub<AgentsStub> {
     private AgentsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -835,9 +764,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.GetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Agent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -851,9 +778,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.SetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Agent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getSetAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -867,7 +792,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.DeleteAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -889,7 +814,7 @@ public final class AgentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SearchAgentsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSearchAgentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSearchAgentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -906,9 +831,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.TrainAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTrainAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getTrainAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -923,7 +846,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.ExportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -943,7 +866,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.ImportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -962,7 +885,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2.RestoreAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRestoreAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRestoreAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -980,7 +903,7 @@ public final class AgentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ValidationResult>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetValidationResultMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetValidationResultMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1016,11 +939,7 @@ public final class AgentsGrpc {
    * </pre>
    */
   public static final class AgentsBlockingStub
-      extends io.grpc.stub.AbstractStub<AgentsBlockingStub> {
-    private AgentsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AgentsBlockingStub> {
     private AgentsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1039,7 +958,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Agent getAgent(
         com.google.cloud.dialogflow.v2.GetAgentRequest request) {
-      return blockingUnaryCall(getChannel(), getGetAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1051,7 +970,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Agent setAgent(
         com.google.cloud.dialogflow.v2.SetAgentRequest request) {
-      return blockingUnaryCall(getChannel(), getSetAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1063,8 +982,7 @@ public final class AgentsGrpc {
      */
     public com.google.protobuf.Empty deleteAgent(
         com.google.cloud.dialogflow.v2.DeleteAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1081,8 +999,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.SearchAgentsResponse searchAgents(
         com.google.cloud.dialogflow.v2.SearchAgentsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSearchAgentsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSearchAgentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1095,8 +1012,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation trainAgent(
         com.google.cloud.dialogflow.v2.TrainAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getTrainAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getTrainAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1109,8 +1025,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation exportAgent(
         com.google.cloud.dialogflow.v2.ExportAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1126,8 +1041,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation importAgent(
         com.google.cloud.dialogflow.v2.ImportAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1142,8 +1056,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation restoreAgent(
         com.google.cloud.dialogflow.v2.RestoreAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getRestoreAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getRestoreAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1157,7 +1070,7 @@ public final class AgentsGrpc {
     public com.google.cloud.dialogflow.v2.ValidationResult getValidationResult(
         com.google.cloud.dialogflow.v2.GetValidationResultRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetValidationResultMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetValidationResultMethod(), getCallOptions(), request);
     }
   }
 
@@ -1190,11 +1103,8 @@ public final class AgentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
    * </pre>
    */
-  public static final class AgentsFutureStub extends io.grpc.stub.AbstractStub<AgentsFutureStub> {
-    private AgentsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AgentsFutureStub
+      extends io.grpc.stub.AbstractFutureStub<AgentsFutureStub> {
     private AgentsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1213,8 +1123,7 @@ public final class AgentsGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dialogflow.v2.Agent>
         getAgent(com.google.cloud.dialogflow.v2.GetAgentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetAgentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1226,8 +1135,7 @@ public final class AgentsGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dialogflow.v2.Agent>
         setAgent(com.google.cloud.dialogflow.v2.SetAgentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getSetAgentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getSetAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1240,7 +1148,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteAgent(com.google.cloud.dialogflow.v2.DeleteAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1259,7 +1167,7 @@ public final class AgentsGrpc {
             com.google.cloud.dialogflow.v2.SearchAgentsResponse>
         searchAgents(com.google.cloud.dialogflow.v2.SearchAgentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSearchAgentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSearchAgentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1273,7 +1181,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         trainAgent(com.google.cloud.dialogflow.v2.TrainAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTrainAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTrainAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1287,7 +1195,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportAgent(com.google.cloud.dialogflow.v2.ExportAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1304,7 +1212,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importAgent(com.google.cloud.dialogflow.v2.ImportAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1320,7 +1228,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         restoreAgent(com.google.cloud.dialogflow.v2.RestoreAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRestoreAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRestoreAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1335,7 +1243,7 @@ public final class AgentsGrpc {
             com.google.cloud.dialogflow.v2.ValidationResult>
         getValidationResult(com.google.cloud.dialogflow.v2.GetValidationResultRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetValidationResultMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetValidationResultMethod(), getCallOptions()), request);
     }
   }
 
@@ -1475,15 +1383,15 @@ public final class AgentsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AgentsFileDescriptorSupplier())
-                      .addMethod(getGetAgentMethodHelper())
-                      .addMethod(getSetAgentMethodHelper())
-                      .addMethod(getDeleteAgentMethodHelper())
-                      .addMethod(getSearchAgentsMethodHelper())
-                      .addMethod(getTrainAgentMethodHelper())
-                      .addMethod(getExportAgentMethodHelper())
-                      .addMethod(getImportAgentMethodHelper())
-                      .addMethod(getRestoreAgentMethodHelper())
-                      .addMethod(getGetValidationResultMethodHelper())
+                      .addMethod(getGetAgentMethod())
+                      .addMethod(getSetAgentMethod())
+                      .addMethod(getDeleteAgentMethod())
+                      .addMethod(getSearchAgentsMethod())
+                      .addMethod(getTrainAgentMethod())
+                      .addMethod(getExportAgentMethod())
+                      .addMethod(getImportAgentMethod())
+                      .addMethod(getRestoreAgentMethod())
+                      .addMethod(getGetValidationResultMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/ContextsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/ContextsGrpc.java
@@ -45,7 +45,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/context.proto")
 public final class ContextsGrpc {
 
@@ -54,30 +54,20 @@ public final class ContextsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.Contexts";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListContextsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListContextsRequest,
-          com.google.cloud.dialogflow.v2.ListContextsResponse>
-      METHOD_LIST_CONTEXTS = getListContextsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListContextsRequest,
           com.google.cloud.dialogflow.v2.ListContextsResponse>
       getListContextsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListContexts",
+      requestType = com.google.cloud.dialogflow.v2.ListContextsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.ListContextsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListContextsRequest,
           com.google.cloud.dialogflow.v2.ListContextsResponse>
       getListContextsMethod() {
-    return getListContextsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListContextsRequest,
-          com.google.cloud.dialogflow.v2.ListContextsResponse>
-      getListContextsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ListContextsRequest,
             com.google.cloud.dialogflow.v2.ListContextsResponse>
@@ -92,9 +82,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2.ListContextsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "ListContexts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListContexts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -112,26 +100,18 @@ public final class ContextsGrpc {
     return getListContextsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetContextRequest, com.google.cloud.dialogflow.v2.Context>
-      METHOD_GET_CONTEXT = getGetContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetContextRequest, com.google.cloud.dialogflow.v2.Context>
       getGetContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetContext",
+      requestType = com.google.cloud.dialogflow.v2.GetContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetContextRequest, com.google.cloud.dialogflow.v2.Context>
       getGetContextMethod() {
-    return getGetContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetContextRequest, com.google.cloud.dialogflow.v2.Context>
-      getGetContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetContextRequest,
             com.google.cloud.dialogflow.v2.Context>
@@ -146,9 +126,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "GetContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,30 +143,20 @@ public final class ContextsGrpc {
     return getGetContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateContextRequest,
-          com.google.cloud.dialogflow.v2.Context>
-      METHOD_CREATE_CONTEXT = getCreateContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateContextRequest,
           com.google.cloud.dialogflow.v2.Context>
       getCreateContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateContext",
+      requestType = com.google.cloud.dialogflow.v2.CreateContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateContextRequest,
           com.google.cloud.dialogflow.v2.Context>
       getCreateContextMethod() {
-    return getCreateContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateContextRequest,
-          com.google.cloud.dialogflow.v2.Context>
-      getCreateContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.CreateContextRequest,
             com.google.cloud.dialogflow.v2.Context>
@@ -203,9 +171,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "CreateContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -222,30 +188,20 @@ public final class ContextsGrpc {
     return getCreateContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateContextRequest,
-          com.google.cloud.dialogflow.v2.Context>
-      METHOD_UPDATE_CONTEXT = getUpdateContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateContextRequest,
           com.google.cloud.dialogflow.v2.Context>
       getUpdateContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateContext",
+      requestType = com.google.cloud.dialogflow.v2.UpdateContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateContextRequest,
           com.google.cloud.dialogflow.v2.Context>
       getUpdateContextMethod() {
-    return getUpdateContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateContextRequest,
-          com.google.cloud.dialogflow.v2.Context>
-      getUpdateContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.UpdateContextRequest,
             com.google.cloud.dialogflow.v2.Context>
@@ -260,9 +216,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "UpdateContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -279,26 +233,18 @@ public final class ContextsGrpc {
     return getUpdateContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteContextRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_CONTEXT = getDeleteContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteContextRequest, com.google.protobuf.Empty>
       getDeleteContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteContext",
+      requestType = com.google.cloud.dialogflow.v2.DeleteContextRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteContextRequest, com.google.protobuf.Empty>
       getDeleteContextMethod() {
-    return getDeleteContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteContextRequest, com.google.protobuf.Empty>
-      getDeleteContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteContextRequest, com.google.protobuf.Empty>
         getDeleteContextMethod;
@@ -312,9 +258,7 @@ public final class ContextsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "DeleteContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -331,26 +275,18 @@ public final class ContextsGrpc {
     return getDeleteContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAllContextsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteAllContextsRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ALL_CONTEXTS = getDeleteAllContextsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteAllContextsRequest, com.google.protobuf.Empty>
       getDeleteAllContextsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAllContexts",
+      requestType = com.google.cloud.dialogflow.v2.DeleteAllContextsRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteAllContextsRequest, com.google.protobuf.Empty>
       getDeleteAllContextsMethod() {
-    return getDeleteAllContextsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteAllContextsRequest, com.google.protobuf.Empty>
-      getDeleteAllContextsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteAllContextsRequest, com.google.protobuf.Empty>
         getDeleteAllContextsMethod;
@@ -364,9 +300,7 @@ public final class ContextsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Contexts", "DeleteAllContexts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteAllContexts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -386,19 +320,42 @@ public final class ContextsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ContextsStub newStub(io.grpc.Channel channel) {
-    return new ContextsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsStub>() {
+          @java.lang.Override
+          public ContextsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsStub(channel, callOptions);
+          }
+        };
+    return ContextsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ContextsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ContextsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsBlockingStub>() {
+          @java.lang.Override
+          public ContextsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsBlockingStub(channel, callOptions);
+          }
+        };
+    return ContextsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ContextsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ContextsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsFutureStub>() {
+          @java.lang.Override
+          public ContextsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsFutureStub(channel, callOptions);
+          }
+        };
+    return ContextsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -436,7 +393,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.ListContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListContextsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListContextsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListContextsMethod(), responseObserver);
     }
 
     /**
@@ -449,7 +406,7 @@ public final class ContextsGrpc {
     public void getContext(
         com.google.cloud.dialogflow.v2.GetContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetContextMethod(), responseObserver);
     }
 
     /**
@@ -463,7 +420,7 @@ public final class ContextsGrpc {
     public void createContext(
         com.google.cloud.dialogflow.v2.CreateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateContextMethod(), responseObserver);
     }
 
     /**
@@ -476,7 +433,7 @@ public final class ContextsGrpc {
     public void updateContext(
         com.google.cloud.dialogflow.v2.UpdateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateContextMethod(), responseObserver);
     }
 
     /**
@@ -489,7 +446,7 @@ public final class ContextsGrpc {
     public void deleteContext(
         com.google.cloud.dialogflow.v2.DeleteContextRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteContextMethod(), responseObserver);
     }
 
     /**
@@ -502,45 +459,45 @@ public final class ContextsGrpc {
     public void deleteAllContexts(
         com.google.cloud.dialogflow.v2.DeleteAllContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAllContextsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAllContextsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListContextsMethodHelper(),
+              getListContextsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ListContextsRequest,
                       com.google.cloud.dialogflow.v2.ListContextsResponse>(
                       this, METHODID_LIST_CONTEXTS)))
           .addMethod(
-              getGetContextMethodHelper(),
+              getGetContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetContextRequest,
                       com.google.cloud.dialogflow.v2.Context>(this, METHODID_GET_CONTEXT)))
           .addMethod(
-              getCreateContextMethodHelper(),
+              getCreateContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.CreateContextRequest,
                       com.google.cloud.dialogflow.v2.Context>(this, METHODID_CREATE_CONTEXT)))
           .addMethod(
-              getUpdateContextMethodHelper(),
+              getUpdateContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.UpdateContextRequest,
                       com.google.cloud.dialogflow.v2.Context>(this, METHODID_UPDATE_CONTEXT)))
           .addMethod(
-              getDeleteContextMethodHelper(),
+              getDeleteContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteContextRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_CONTEXT)))
           .addMethod(
-              getDeleteAllContextsMethodHelper(),
+              getDeleteAllContextsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteAllContextsRequest,
@@ -571,11 +528,7 @@ public final class ContextsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
    * </pre>
    */
-  public static final class ContextsStub extends io.grpc.stub.AbstractStub<ContextsStub> {
-    private ContextsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class ContextsStub extends io.grpc.stub.AbstractAsyncStub<ContextsStub> {
     private ContextsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -597,7 +550,7 @@ public final class ContextsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListContextsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListContextsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListContextsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -613,9 +566,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.GetContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetContextMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetContextMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -630,7 +581,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.CreateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -646,7 +597,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.UpdateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -662,7 +613,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.DeleteContextRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -678,7 +629,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2.DeleteAllContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAllContextsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAllContextsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -707,11 +658,7 @@ public final class ContextsGrpc {
    * </pre>
    */
   public static final class ContextsBlockingStub
-      extends io.grpc.stub.AbstractStub<ContextsBlockingStub> {
-    private ContextsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ContextsBlockingStub> {
     private ContextsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -730,8 +677,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2.ListContextsResponse listContexts(
         com.google.cloud.dialogflow.v2.ListContextsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListContextsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListContextsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -743,8 +689,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Context getContext(
         com.google.cloud.dialogflow.v2.GetContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -757,8 +702,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Context createContext(
         com.google.cloud.dialogflow.v2.CreateContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -770,8 +714,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Context updateContext(
         com.google.cloud.dialogflow.v2.UpdateContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -783,8 +726,7 @@ public final class ContextsGrpc {
      */
     public com.google.protobuf.Empty deleteContext(
         com.google.cloud.dialogflow.v2.DeleteContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -797,7 +739,7 @@ public final class ContextsGrpc {
     public com.google.protobuf.Empty deleteAllContexts(
         com.google.cloud.dialogflow.v2.DeleteAllContextsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteAllContextsMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteAllContextsMethod(), getCallOptions(), request);
     }
   }
 
@@ -824,11 +766,7 @@ public final class ContextsGrpc {
    * </pre>
    */
   public static final class ContextsFutureStub
-      extends io.grpc.stub.AbstractStub<ContextsFutureStub> {
-    private ContextsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ContextsFutureStub> {
     private ContextsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -849,7 +787,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2.ListContextsResponse>
         listContexts(com.google.cloud.dialogflow.v2.ListContextsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListContextsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListContextsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -863,7 +801,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2.Context>
         getContext(com.google.cloud.dialogflow.v2.GetContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -878,7 +816,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2.Context>
         createContext(com.google.cloud.dialogflow.v2.CreateContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -892,7 +830,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2.Context>
         updateContext(com.google.cloud.dialogflow.v2.UpdateContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -905,7 +843,7 @@ public final class ContextsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteContext(com.google.cloud.dialogflow.v2.DeleteContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -918,7 +856,7 @@ public final class ContextsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteAllContexts(com.google.cloud.dialogflow.v2.DeleteAllContextsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAllContextsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteAllContextsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1042,12 +980,12 @@ public final class ContextsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ContextsFileDescriptorSupplier())
-                      .addMethod(getListContextsMethodHelper())
-                      .addMethod(getGetContextMethodHelper())
-                      .addMethod(getCreateContextMethodHelper())
-                      .addMethod(getUpdateContextMethodHelper())
-                      .addMethod(getDeleteContextMethodHelper())
-                      .addMethod(getDeleteAllContextsMethodHelper())
+                      .addMethod(getListContextsMethod())
+                      .addMethod(getGetContextMethod())
+                      .addMethod(getCreateContextMethod())
+                      .addMethod(getUpdateContextMethod())
+                      .addMethod(getDeleteContextMethod())
+                      .addMethod(getDeleteAllContextsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/EntityTypesGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/EntityTypesGrpc.java
@@ -51,7 +51,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/entity_type.proto")
 public final class EntityTypesGrpc {
 
@@ -60,30 +60,20 @@ public final class EntityTypesGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.EntityTypes";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
-          com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
-      METHOD_LIST_ENTITY_TYPES = getListEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
           com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
       getListEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2.ListEntityTypesRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.ListEntityTypesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
           com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
       getListEntityTypesMethod() {
-    return getListEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
-          com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
-      getListEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
             com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
@@ -98,9 +88,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "ListEntityTypes"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -119,30 +107,20 @@ public final class EntityTypesGrpc {
     return getListEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      METHOD_GET_ENTITY_TYPE = getGetEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getGetEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetEntityType",
+      requestType = com.google.cloud.dialogflow.v2.GetEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getGetEntityTypeMethod() {
-    return getGetEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      getGetEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
             com.google.cloud.dialogflow.v2.EntityType>
@@ -157,9 +135,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "GetEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -176,30 +152,20 @@ public final class EntityTypesGrpc {
     return getGetEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      METHOD_CREATE_ENTITY_TYPE = getCreateEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getCreateEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateEntityType",
+      requestType = com.google.cloud.dialogflow.v2.CreateEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getCreateEntityTypeMethod() {
-    return getCreateEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      getCreateEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
             com.google.cloud.dialogflow.v2.EntityType>
@@ -214,9 +180,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "CreateEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -234,30 +198,20 @@ public final class EntityTypesGrpc {
     return getCreateEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      METHOD_UPDATE_ENTITY_TYPE = getUpdateEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getUpdateEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateEntityType",
+      requestType = com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
           com.google.cloud.dialogflow.v2.EntityType>
       getUpdateEntityTypeMethod() {
-    return getUpdateEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.EntityType>
-      getUpdateEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
             com.google.cloud.dialogflow.v2.EntityType>
@@ -272,9 +226,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "UpdateEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -292,26 +244,18 @@ public final class EntityTypesGrpc {
     return getUpdateEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ENTITY_TYPE = getDeleteEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteEntityType",
+      requestType = com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteEntityTypeMethod() {
-    return getDeleteEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest, com.google.protobuf.Empty>
-      getDeleteEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest, com.google.protobuf.Empty>
         getDeleteEntityTypeMethod;
@@ -325,9 +269,7 @@ public final class EntityTypesGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "DeleteEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -345,30 +287,20 @@ public final class EntityTypesGrpc {
     return getDeleteEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_ENTITY_TYPES = getBatchUpdateEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntityTypesMethod() {
-    return getBatchUpdateEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
             com.google.longrunning.Operation>
@@ -386,8 +318,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "BatchUpdateEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "BatchUpdateEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -405,30 +336,20 @@ public final class EntityTypesGrpc {
     return getBatchUpdateEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_ENTITY_TYPES = getBatchDeleteEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntityTypesMethod() {
-    return getBatchDeleteEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
             com.google.longrunning.Operation>
@@ -446,8 +367,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "BatchDeleteEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "BatchDeleteEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -465,30 +385,20 @@ public final class EntityTypesGrpc {
     return getBatchDeleteEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchCreateEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_CREATE_ENTITIES = getBatchCreateEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchCreateEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchCreateEntities",
+      requestType = com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchCreateEntitiesMethod() {
-    return getBatchCreateEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchCreateEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
             com.google.longrunning.Operation>
@@ -504,8 +414,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "BatchCreateEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchCreateEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -523,30 +432,20 @@ public final class EntityTypesGrpc {
     return getBatchCreateEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_ENTITIES = getBatchUpdateEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateEntities",
+      requestType = com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntitiesMethod() {
-    return getBatchUpdateEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
             com.google.longrunning.Operation>
@@ -562,8 +461,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "BatchUpdateEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchUpdateEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -581,30 +479,20 @@ public final class EntityTypesGrpc {
     return getBatchUpdateEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_ENTITIES = getBatchDeleteEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteEntities",
+      requestType = com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntitiesMethod() {
-    return getBatchDeleteEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
             com.google.longrunning.Operation>
@@ -620,8 +508,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.EntityTypes", "BatchDeleteEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchDeleteEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -641,19 +528,42 @@ public final class EntityTypesGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static EntityTypesStub newStub(io.grpc.Channel channel) {
-    return new EntityTypesStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesStub>() {
+          @java.lang.Override
+          public EntityTypesStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesStub(channel, callOptions);
+          }
+        };
+    return EntityTypesStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static EntityTypesBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new EntityTypesBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesBlockingStub>() {
+          @java.lang.Override
+          public EntityTypesBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesBlockingStub(channel, callOptions);
+          }
+        };
+    return EntityTypesBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static EntityTypesFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new EntityTypesFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesFutureStub>() {
+          @java.lang.Override
+          public EntityTypesFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesFutureStub(channel, callOptions);
+          }
+        };
+    return EntityTypesFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -697,7 +607,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.ListEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -710,7 +620,7 @@ public final class EntityTypesGrpc {
     public void getEntityType(
         com.google.cloud.dialogflow.v2.GetEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -723,7 +633,7 @@ public final class EntityTypesGrpc {
     public void createEntityType(
         com.google.cloud.dialogflow.v2.CreateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -736,7 +646,7 @@ public final class EntityTypesGrpc {
     public void updateEntityType(
         com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -749,7 +659,7 @@ public final class EntityTypesGrpc {
     public void deleteEntityType(
         com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -763,7 +673,7 @@ public final class EntityTypesGrpc {
     public void batchUpdateEntityTypes(
         com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -777,7 +687,7 @@ public final class EntityTypesGrpc {
     public void batchDeleteEntityTypes(
         com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -791,7 +701,7 @@ public final class EntityTypesGrpc {
     public void batchCreateEntities(
         com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchCreateEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchCreateEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -807,7 +717,7 @@ public final class EntityTypesGrpc {
     public void batchUpdateEntities(
         com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -821,71 +731,71 @@ public final class EntityTypesGrpc {
     public void batchDeleteEntities(
         com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteEntitiesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListEntityTypesMethodHelper(),
+              getListEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ListEntityTypesRequest,
                       com.google.cloud.dialogflow.v2.ListEntityTypesResponse>(
                       this, METHODID_LIST_ENTITY_TYPES)))
           .addMethod(
-              getGetEntityTypeMethodHelper(),
+              getGetEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.EntityType>(this, METHODID_GET_ENTITY_TYPE)))
           .addMethod(
-              getCreateEntityTypeMethodHelper(),
+              getCreateEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.CreateEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.EntityType>(
                       this, METHODID_CREATE_ENTITY_TYPE)))
           .addMethod(
-              getUpdateEntityTypeMethodHelper(),
+              getUpdateEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.EntityType>(
                       this, METHODID_UPDATE_ENTITY_TYPE)))
           .addMethod(
-              getDeleteEntityTypeMethodHelper(),
+              getDeleteEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_ENTITY_TYPE)))
           .addMethod(
-              getBatchUpdateEntityTypesMethodHelper(),
+              getBatchUpdateEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_ENTITY_TYPES)))
           .addMethod(
-              getBatchDeleteEntityTypesMethodHelper(),
+              getBatchDeleteEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_DELETE_ENTITY_TYPES)))
           .addMethod(
-              getBatchCreateEntitiesMethodHelper(),
+              getBatchCreateEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_CREATE_ENTITIES)))
           .addMethod(
-              getBatchUpdateEntitiesMethodHelper(),
+              getBatchUpdateEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_ENTITIES)))
           .addMethod(
-              getBatchDeleteEntitiesMethodHelper(),
+              getBatchDeleteEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest,
@@ -922,11 +832,8 @@ public final class EntityTypesGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
    * </pre>
    */
-  public static final class EntityTypesStub extends io.grpc.stub.AbstractStub<EntityTypesStub> {
-    private EntityTypesStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class EntityTypesStub
+      extends io.grpc.stub.AbstractAsyncStub<EntityTypesStub> {
     private EntityTypesStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -948,7 +855,7 @@ public final class EntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -964,7 +871,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.GetEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -980,7 +887,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.CreateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -996,7 +903,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.EntityType> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1012,7 +919,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1029,7 +936,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1046,7 +953,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1063,7 +970,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchCreateEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchCreateEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1082,7 +989,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1099,7 +1006,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1134,11 +1041,7 @@ public final class EntityTypesGrpc {
    * </pre>
    */
   public static final class EntityTypesBlockingStub
-      extends io.grpc.stub.AbstractStub<EntityTypesBlockingStub> {
-    private EntityTypesBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<EntityTypesBlockingStub> {
     private EntityTypesBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1158,8 +1061,7 @@ public final class EntityTypesGrpc {
      */
     public com.google.cloud.dialogflow.v2.ListEntityTypesResponse listEntityTypes(
         com.google.cloud.dialogflow.v2.ListEntityTypesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEntityTypesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1171,8 +1073,7 @@ public final class EntityTypesGrpc {
      */
     public com.google.cloud.dialogflow.v2.EntityType getEntityType(
         com.google.cloud.dialogflow.v2.GetEntityTypeRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetEntityTypeMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1185,7 +1086,7 @@ public final class EntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.EntityType createEntityType(
         com.google.cloud.dialogflow.v2.CreateEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1198,7 +1099,7 @@ public final class EntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.EntityType updateEntityType(
         com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1211,7 +1112,7 @@ public final class EntityTypesGrpc {
     public com.google.protobuf.Empty deleteEntityType(
         com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1225,7 +1126,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchUpdateEntityTypes(
         com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1239,7 +1140,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchDeleteEntityTypes(
         com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1253,7 +1154,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchCreateEntities(
         com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchCreateEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchCreateEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1269,7 +1170,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchUpdateEntities(
         com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1283,7 +1184,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchDeleteEntities(
         com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteEntitiesMethod(), getCallOptions(), request);
     }
   }
 
@@ -1316,11 +1217,7 @@ public final class EntityTypesGrpc {
    * </pre>
    */
   public static final class EntityTypesFutureStub
-      extends io.grpc.stub.AbstractStub<EntityTypesFutureStub> {
-    private EntityTypesFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<EntityTypesFutureStub> {
     private EntityTypesFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1342,7 +1239,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2.ListEntityTypesResponse>
         listEntityTypes(com.google.cloud.dialogflow.v2.ListEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1356,7 +1253,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2.EntityType>
         getEntityType(com.google.cloud.dialogflow.v2.GetEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1370,7 +1267,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2.EntityType>
         createEntityType(com.google.cloud.dialogflow.v2.CreateEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1384,7 +1281,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2.EntityType>
         updateEntityType(com.google.cloud.dialogflow.v2.UpdateEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1397,7 +1294,7 @@ public final class EntityTypesGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteEntityType(com.google.cloud.dialogflow.v2.DeleteEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1412,7 +1309,7 @@ public final class EntityTypesGrpc {
         batchUpdateEntityTypes(
             com.google.cloud.dialogflow.v2.BatchUpdateEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1427,7 +1324,7 @@ public final class EntityTypesGrpc {
         batchDeleteEntityTypes(
             com.google.cloud.dialogflow.v2.BatchDeleteEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1441,7 +1338,7 @@ public final class EntityTypesGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchCreateEntities(com.google.cloud.dialogflow.v2.BatchCreateEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchCreateEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchCreateEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1457,7 +1354,7 @@ public final class EntityTypesGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchUpdateEntities(com.google.cloud.dialogflow.v2.BatchUpdateEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1471,7 +1368,7 @@ public final class EntityTypesGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchDeleteEntities(com.google.cloud.dialogflow.v2.BatchDeleteEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteEntitiesMethod(), getCallOptions()), request);
     }
   }
 
@@ -1621,16 +1518,16 @@ public final class EntityTypesGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new EntityTypesFileDescriptorSupplier())
-                      .addMethod(getListEntityTypesMethodHelper())
-                      .addMethod(getGetEntityTypeMethodHelper())
-                      .addMethod(getCreateEntityTypeMethodHelper())
-                      .addMethod(getUpdateEntityTypeMethodHelper())
-                      .addMethod(getDeleteEntityTypeMethodHelper())
-                      .addMethod(getBatchUpdateEntityTypesMethodHelper())
-                      .addMethod(getBatchDeleteEntityTypesMethodHelper())
-                      .addMethod(getBatchCreateEntitiesMethodHelper())
-                      .addMethod(getBatchUpdateEntitiesMethodHelper())
-                      .addMethod(getBatchDeleteEntitiesMethodHelper())
+                      .addMethod(getListEntityTypesMethod())
+                      .addMethod(getGetEntityTypeMethod())
+                      .addMethod(getCreateEntityTypeMethod())
+                      .addMethod(getUpdateEntityTypeMethod())
+                      .addMethod(getDeleteEntityTypeMethod())
+                      .addMethod(getBatchUpdateEntityTypesMethod())
+                      .addMethod(getBatchDeleteEntityTypesMethod())
+                      .addMethod(getBatchCreateEntitiesMethod())
+                      .addMethod(getBatchUpdateEntitiesMethod())
+                      .addMethod(getBatchDeleteEntitiesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/IntentsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/IntentsGrpc.java
@@ -56,7 +56,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/intent.proto")
 public final class IntentsGrpc {
 
@@ -65,30 +65,20 @@ public final class IntentsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.Intents";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListIntentsRequest,
-          com.google.cloud.dialogflow.v2.ListIntentsResponse>
-      METHOD_LIST_INTENTS = getListIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListIntentsRequest,
           com.google.cloud.dialogflow.v2.ListIntentsResponse>
       getListIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListIntents",
+      requestType = com.google.cloud.dialogflow.v2.ListIntentsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.ListIntentsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListIntentsRequest,
           com.google.cloud.dialogflow.v2.ListIntentsResponse>
       getListIntentsMethod() {
-    return getListIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListIntentsRequest,
-          com.google.cloud.dialogflow.v2.ListIntentsResponse>
-      getListIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ListIntentsRequest,
             com.google.cloud.dialogflow.v2.ListIntentsResponse>
@@ -103,9 +93,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2.ListIntentsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "ListIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -123,26 +111,18 @@ public final class IntentsGrpc {
     return getListIntentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      METHOD_GET_INTENT = getGetIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getGetIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIntent",
+      requestType = com.google.cloud.dialogflow.v2.GetIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getGetIntentMethod() {
-    return getGetIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      getGetIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetIntentRequest, com.google.cloud.dialogflow.v2.Intent>
         getGetIntentMethod;
@@ -156,8 +136,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.dialogflow.v2.Intents", "GetIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -173,26 +152,18 @@ public final class IntentsGrpc {
     return getGetIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      METHOD_CREATE_INTENT = getCreateIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getCreateIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateIntent",
+      requestType = com.google.cloud.dialogflow.v2.CreateIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getCreateIntentMethod() {
-    return getCreateIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      getCreateIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.CreateIntentRequest,
             com.google.cloud.dialogflow.v2.Intent>
@@ -207,9 +178,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "CreateIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -226,26 +195,18 @@ public final class IntentsGrpc {
     return getCreateIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      METHOD_UPDATE_INTENT = getUpdateIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getUpdateIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateIntent",
+      requestType = com.google.cloud.dialogflow.v2.UpdateIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
       getUpdateIntentMethod() {
-    return getUpdateIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateIntentRequest, com.google.cloud.dialogflow.v2.Intent>
-      getUpdateIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.UpdateIntentRequest,
             com.google.cloud.dialogflow.v2.Intent>
@@ -260,9 +221,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "UpdateIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -279,26 +238,18 @@ public final class IntentsGrpc {
     return getUpdateIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteIntentRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_INTENT = getDeleteIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteIntentRequest, com.google.protobuf.Empty>
       getDeleteIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteIntent",
+      requestType = com.google.cloud.dialogflow.v2.DeleteIntentRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteIntentRequest, com.google.protobuf.Empty>
       getDeleteIntentMethod() {
-    return getDeleteIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteIntentRequest, com.google.protobuf.Empty>
-      getDeleteIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteIntentRequest, com.google.protobuf.Empty>
         getDeleteIntentMethod;
@@ -312,9 +263,7 @@ public final class IntentsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "DeleteIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -331,30 +280,20 @@ public final class IntentsGrpc {
     return getDeleteIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_INTENTS = getBatchUpdateIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
           com.google.longrunning.Operation>
       getBatchUpdateIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateIntents",
+      requestType = com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
           com.google.longrunning.Operation>
       getBatchUpdateIntentsMethod() {
-    return getBatchUpdateIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
             com.google.longrunning.Operation>
@@ -369,9 +308,7 @@ public final class IntentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "BatchUpdateIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchUpdateIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -389,30 +326,20 @@ public final class IntentsGrpc {
     return getBatchUpdateIntentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_INTENTS = getBatchDeleteIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
           com.google.longrunning.Operation>
       getBatchDeleteIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteIntents",
+      requestType = com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
           com.google.longrunning.Operation>
       getBatchDeleteIntentsMethod() {
-    return getBatchDeleteIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
             com.google.longrunning.Operation>
@@ -427,9 +354,7 @@ public final class IntentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Intents", "BatchDeleteIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchDeleteIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -449,19 +374,42 @@ public final class IntentsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static IntentsStub newStub(io.grpc.Channel channel) {
-    return new IntentsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsStub>() {
+          @java.lang.Override
+          public IntentsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsStub(channel, callOptions);
+          }
+        };
+    return IntentsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static IntentsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new IntentsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsBlockingStub>() {
+          @java.lang.Override
+          public IntentsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsBlockingStub(channel, callOptions);
+          }
+        };
+    return IntentsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static IntentsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new IntentsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsFutureStub>() {
+          @java.lang.Override
+          public IntentsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsFutureStub(channel, callOptions);
+          }
+        };
+    return IntentsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -510,7 +458,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.ListIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListIntentsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListIntentsMethod(), responseObserver);
     }
 
     /**
@@ -523,7 +471,7 @@ public final class IntentsGrpc {
     public void getIntent(
         com.google.cloud.dialogflow.v2.GetIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIntentMethod(), responseObserver);
     }
 
     /**
@@ -536,7 +484,7 @@ public final class IntentsGrpc {
     public void createIntent(
         com.google.cloud.dialogflow.v2.CreateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateIntentMethod(), responseObserver);
     }
 
     /**
@@ -549,7 +497,7 @@ public final class IntentsGrpc {
     public void updateIntent(
         com.google.cloud.dialogflow.v2.UpdateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateIntentMethod(), responseObserver);
     }
 
     /**
@@ -562,7 +510,7 @@ public final class IntentsGrpc {
     public void deleteIntent(
         com.google.cloud.dialogflow.v2.DeleteIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteIntentMethod(), responseObserver);
     }
 
     /**
@@ -576,7 +524,7 @@ public final class IntentsGrpc {
     public void batchUpdateIntents(
         com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateIntentsMethod(), responseObserver);
     }
 
     /**
@@ -590,51 +538,51 @@ public final class IntentsGrpc {
     public void batchDeleteIntents(
         com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteIntentsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListIntentsMethodHelper(),
+              getListIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ListIntentsRequest,
                       com.google.cloud.dialogflow.v2.ListIntentsResponse>(
                       this, METHODID_LIST_INTENTS)))
           .addMethod(
-              getGetIntentMethodHelper(),
+              getGetIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetIntentRequest,
                       com.google.cloud.dialogflow.v2.Intent>(this, METHODID_GET_INTENT)))
           .addMethod(
-              getCreateIntentMethodHelper(),
+              getCreateIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.CreateIntentRequest,
                       com.google.cloud.dialogflow.v2.Intent>(this, METHODID_CREATE_INTENT)))
           .addMethod(
-              getUpdateIntentMethodHelper(),
+              getUpdateIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.UpdateIntentRequest,
                       com.google.cloud.dialogflow.v2.Intent>(this, METHODID_UPDATE_INTENT)))
           .addMethod(
-              getDeleteIntentMethodHelper(),
+              getDeleteIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteIntentRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_INTENT)))
           .addMethod(
-              getBatchUpdateIntentsMethodHelper(),
+              getBatchUpdateIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_INTENTS)))
           .addMethod(
-              getBatchDeleteIntentsMethodHelper(),
+              getBatchDeleteIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest,
@@ -676,11 +624,7 @@ public final class IntentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
    * </pre>
    */
-  public static final class IntentsStub extends io.grpc.stub.AbstractStub<IntentsStub> {
-    private IntentsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class IntentsStub extends io.grpc.stub.AbstractAsyncStub<IntentsStub> {
     private IntentsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -702,7 +646,7 @@ public final class IntentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListIntentsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -718,9 +662,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.GetIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIntentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetIntentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -734,7 +676,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.CreateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -750,7 +692,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.UpdateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -766,7 +708,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.DeleteIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -783,7 +725,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -800,7 +742,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -840,11 +782,7 @@ public final class IntentsGrpc {
    * </pre>
    */
   public static final class IntentsBlockingStub
-      extends io.grpc.stub.AbstractStub<IntentsBlockingStub> {
-    private IntentsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<IntentsBlockingStub> {
     private IntentsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -863,8 +801,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.ListIntentsResponse listIntents(
         com.google.cloud.dialogflow.v2.ListIntentsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListIntentsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListIntentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -876,7 +813,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Intent getIntent(
         com.google.cloud.dialogflow.v2.GetIntentRequest request) {
-      return blockingUnaryCall(getChannel(), getGetIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -888,8 +825,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Intent createIntent(
         com.google.cloud.dialogflow.v2.CreateIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -901,8 +837,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2.Intent updateIntent(
         com.google.cloud.dialogflow.v2.UpdateIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -914,8 +849,7 @@ public final class IntentsGrpc {
      */
     public com.google.protobuf.Empty deleteIntent(
         com.google.cloud.dialogflow.v2.DeleteIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -929,7 +863,7 @@ public final class IntentsGrpc {
     public com.google.longrunning.Operation batchUpdateIntents(
         com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateIntentsMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateIntentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -943,7 +877,7 @@ public final class IntentsGrpc {
     public com.google.longrunning.Operation batchDeleteIntents(
         com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteIntentsMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteIntentsMethod(), getCallOptions(), request);
     }
   }
 
@@ -980,11 +914,8 @@ public final class IntentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
    * </pre>
    */
-  public static final class IntentsFutureStub extends io.grpc.stub.AbstractStub<IntentsFutureStub> {
-    private IntentsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class IntentsFutureStub
+      extends io.grpc.stub.AbstractFutureStub<IntentsFutureStub> {
     private IntentsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1005,7 +936,7 @@ public final class IntentsGrpc {
             com.google.cloud.dialogflow.v2.ListIntentsResponse>
         listIntents(com.google.cloud.dialogflow.v2.ListIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListIntentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1017,8 +948,7 @@ public final class IntentsGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dialogflow.v2.Intent>
         getIntent(com.google.cloud.dialogflow.v2.GetIntentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetIntentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1031,7 +961,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dialogflow.v2.Intent>
         createIntent(com.google.cloud.dialogflow.v2.CreateIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1044,7 +974,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dialogflow.v2.Intent>
         updateIntent(com.google.cloud.dialogflow.v2.UpdateIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1057,7 +987,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteIntent(com.google.cloud.dialogflow.v2.DeleteIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1071,7 +1001,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchUpdateIntents(com.google.cloud.dialogflow.v2.BatchUpdateIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateIntentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1085,7 +1015,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchDeleteIntents(com.google.cloud.dialogflow.v2.BatchDeleteIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteIntentsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1215,13 +1145,13 @@ public final class IntentsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new IntentsFileDescriptorSupplier())
-                      .addMethod(getListIntentsMethodHelper())
-                      .addMethod(getGetIntentMethodHelper())
-                      .addMethod(getCreateIntentMethodHelper())
-                      .addMethod(getUpdateIntentMethodHelper())
-                      .addMethod(getDeleteIntentMethodHelper())
-                      .addMethod(getBatchUpdateIntentsMethodHelper())
-                      .addMethod(getBatchDeleteIntentsMethodHelper())
+                      .addMethod(getListIntentsMethod())
+                      .addMethod(getGetIntentMethod())
+                      .addMethod(getCreateIntentMethod())
+                      .addMethod(getUpdateIntentMethod())
+                      .addMethod(getDeleteIntentMethod())
+                      .addMethod(getBatchUpdateIntentsMethod())
+                      .addMethod(getBatchDeleteIntentsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/SessionEntityTypesGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/SessionEntityTypesGrpc.java
@@ -43,7 +43,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/session_entity_type.proto")
 public final class SessionEntityTypesGrpc {
 
@@ -52,30 +52,20 @@ public final class SessionEntityTypesGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.SessionEntityTypes";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListSessionEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
-          com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
-      METHOD_LIST_SESSION_ENTITY_TYPES = getListSessionEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
           com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
       getListSessionEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListSessionEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
           com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
       getListSessionEntityTypesMethod() {
-    return getListSessionEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
-          com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
-      getListSessionEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
             com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
@@ -94,9 +84,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.SessionEntityTypes",
-                              "ListSessionEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "ListSessionEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -115,30 +103,20 @@ public final class SessionEntityTypesGrpc {
     return getListSessionEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      METHOD_GET_SESSION_ENTITY_TYPE = getGetSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getGetSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getGetSessionEntityTypeMethod() {
-    return getGetSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      getGetSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2.SessionEntityType>
@@ -156,9 +134,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.SessionEntityTypes",
-                              "GetSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "GetSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -177,30 +153,20 @@ public final class SessionEntityTypesGrpc {
     return getGetSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      METHOD_CREATE_SESSION_ENTITY_TYPE = getCreateSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getCreateSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getCreateSessionEntityTypeMethod() {
-    return getCreateSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      getCreateSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2.SessionEntityType>
@@ -219,9 +185,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.SessionEntityTypes",
-                              "CreateSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "CreateSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -240,30 +204,20 @@ public final class SessionEntityTypesGrpc {
     return getCreateSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      METHOD_UPDATE_SESSION_ENTITY_TYPE = getUpdateSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getUpdateSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2.SessionEntityType>
       getUpdateSessionEntityTypeMethod() {
-    return getUpdateSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2.SessionEntityType>
-      getUpdateSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2.SessionEntityType>
@@ -282,9 +236,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.SessionEntityTypes",
-                              "UpdateSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -303,26 +255,18 @@ public final class SessionEntityTypesGrpc {
     return getUpdateSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_SESSION_ENTITY_TYPE = getDeleteSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteSessionEntityTypeMethod() {
-    return getDeleteSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest, com.google.protobuf.Empty>
-      getDeleteSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest,
             com.google.protobuf.Empty>
@@ -341,9 +285,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.SessionEntityTypes",
-                              "DeleteSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -363,19 +305,43 @@ public final class SessionEntityTypesGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SessionEntityTypesStub newStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesStub>() {
+          @java.lang.Override
+          public SessionEntityTypesStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SessionEntityTypesBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesBlockingStub>() {
+          @java.lang.Override
+          public SessionEntityTypesBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesBlockingStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SessionEntityTypesFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesFutureStub>() {
+          @java.lang.Override
+          public SessionEntityTypesFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesFutureStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -414,7 +380,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListSessionEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListSessionEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -431,7 +397,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -450,7 +416,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -467,7 +433,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -483,42 +449,42 @@ public final class SessionEntityTypesGrpc {
     public void deleteSessionEntityType(
         com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteSessionEntityTypeMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListSessionEntityTypesMethodHelper(),
+              getListSessionEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest,
                       com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>(
                       this, METHODID_LIST_SESSION_ENTITY_TYPES)))
           .addMethod(
-              getGetSessionEntityTypeMethodHelper(),
+              getGetSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.SessionEntityType>(
                       this, METHODID_GET_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getCreateSessionEntityTypeMethodHelper(),
+              getCreateSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.SessionEntityType>(
                       this, METHODID_CREATE_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getUpdateSessionEntityTypeMethodHelper(),
+              getUpdateSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2.SessionEntityType>(
                       this, METHODID_UPDATE_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getDeleteSessionEntityTypeMethodHelper(),
+              getDeleteSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest,
@@ -548,11 +514,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesStub> {
-    private SessionEntityTypesStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<SessionEntityTypesStub> {
     private SessionEntityTypesStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -578,7 +540,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSessionEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListSessionEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -598,7 +560,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -620,7 +582,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -640,7 +602,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -659,7 +621,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -686,11 +648,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesBlockingStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesBlockingStub> {
-    private SessionEntityTypesBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SessionEntityTypesBlockingStub> {
     private SessionEntityTypesBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -715,7 +673,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.ListSessionEntityTypesResponse listSessionEntityTypes(
         com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListSessionEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListSessionEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -731,7 +689,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.SessionEntityType getSessionEntityType(
         com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -749,7 +707,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.SessionEntityType createSessionEntityType(
         com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -765,7 +723,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2.SessionEntityType updateSessionEntityType(
         com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -781,7 +739,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.protobuf.Empty deleteSessionEntityType(
         com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteSessionEntityTypeMethod(), getCallOptions(), request);
     }
   }
 
@@ -806,11 +764,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesFutureStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesFutureStub> {
-    private SessionEntityTypesFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SessionEntityTypesFutureStub> {
     private SessionEntityTypesFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -836,7 +790,7 @@ public final class SessionEntityTypesGrpc {
         listSessionEntityTypes(
             com.google.cloud.dialogflow.v2.ListSessionEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListSessionEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListSessionEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -853,7 +807,7 @@ public final class SessionEntityTypesGrpc {
             com.google.cloud.dialogflow.v2.SessionEntityType>
         getSessionEntityType(com.google.cloud.dialogflow.v2.GetSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetSessionEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -873,8 +827,7 @@ public final class SessionEntityTypesGrpc {
         createSessionEntityType(
             com.google.cloud.dialogflow.v2.CreateSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -892,8 +845,7 @@ public final class SessionEntityTypesGrpc {
         updateSessionEntityType(
             com.google.cloud.dialogflow.v2.UpdateSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -910,8 +862,7 @@ public final class SessionEntityTypesGrpc {
         deleteSessionEntityType(
             com.google.cloud.dialogflow.v2.DeleteSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteSessionEntityTypeMethod(), getCallOptions()), request);
     }
   }
 
@@ -1032,11 +983,11 @@ public final class SessionEntityTypesGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SessionEntityTypesFileDescriptorSupplier())
-                      .addMethod(getListSessionEntityTypesMethodHelper())
-                      .addMethod(getGetSessionEntityTypeMethodHelper())
-                      .addMethod(getCreateSessionEntityTypeMethodHelper())
-                      .addMethod(getUpdateSessionEntityTypeMethodHelper())
-                      .addMethod(getDeleteSessionEntityTypeMethodHelper())
+                      .addMethod(getListSessionEntityTypesMethod())
+                      .addMethod(getGetSessionEntityTypeMethod())
+                      .addMethod(getCreateSessionEntityTypeMethod())
+                      .addMethod(getUpdateSessionEntityTypeMethod())
+                      .addMethod(getDeleteSessionEntityTypeMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/SessionsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/SessionsGrpc.java
@@ -36,7 +36,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2/session.proto")
 public final class SessionsGrpc {
 
@@ -45,30 +45,20 @@ public final class SessionsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2.Sessions";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDetectIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DetectIntentRequest,
-          com.google.cloud.dialogflow.v2.DetectIntentResponse>
-      METHOD_DETECT_INTENT = getDetectIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DetectIntentRequest,
           com.google.cloud.dialogflow.v2.DetectIntentResponse>
       getDetectIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DetectIntent",
+      requestType = com.google.cloud.dialogflow.v2.DetectIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.DetectIntentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.DetectIntentRequest,
           com.google.cloud.dialogflow.v2.DetectIntentResponse>
       getDetectIntentMethod() {
-    return getDetectIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.DetectIntentRequest,
-          com.google.cloud.dialogflow.v2.DetectIntentResponse>
-      getDetectIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.DetectIntentRequest,
             com.google.cloud.dialogflow.v2.DetectIntentResponse>
@@ -83,9 +73,7 @@ public final class SessionsGrpc {
                           com.google.cloud.dialogflow.v2.DetectIntentResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Sessions", "DetectIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DetectIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -103,30 +91,20 @@ public final class SessionsGrpc {
     return getDetectIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getStreamingDetectIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
-          com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
-      METHOD_STREAMING_DETECT_INTENT = getStreamingDetectIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
           com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
       getStreamingDetectIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamingDetectIntent",
+      requestType = com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
           com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
       getStreamingDetectIntentMethod() {
-    return getStreamingDetectIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
-          com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
-      getStreamingDetectIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
             com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
@@ -143,8 +121,7 @@ public final class SessionsGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2.Sessions", "StreamingDetectIntent"))
+                          generateFullMethodName(SERVICE_NAME, "StreamingDetectIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,19 +142,42 @@ public final class SessionsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SessionsStub newStub(io.grpc.Channel channel) {
-    return new SessionsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsStub>() {
+          @java.lang.Override
+          public SessionsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsStub(channel, callOptions);
+          }
+        };
+    return SessionsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SessionsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SessionsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsBlockingStub>() {
+          @java.lang.Override
+          public SessionsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsBlockingStub(channel, callOptions);
+          }
+        };
+    return SessionsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SessionsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SessionsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsFutureStub>() {
+          @java.lang.Override
+          public SessionsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsFutureStub(channel, callOptions);
+          }
+        };
+    return SessionsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -206,7 +206,7 @@ public final class SessionsGrpc {
         com.google.cloud.dialogflow.v2.DetectIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.DetectIntentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getDetectIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDetectIntentMethod(), responseObserver);
     }
 
     /**
@@ -223,22 +223,21 @@ public final class SessionsGrpc {
             io.grpc.stub.StreamObserver<
                     com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
                 responseObserver) {
-      return asyncUnimplementedStreamingCall(
-          getStreamingDetectIntentMethodHelper(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingDetectIntentMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getDetectIntentMethodHelper(),
+              getDetectIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.DetectIntentRequest,
                       com.google.cloud.dialogflow.v2.DetectIntentResponse>(
                       this, METHODID_DETECT_INTENT)))
           .addMethod(
-              getStreamingDetectIntentMethodHelper(),
+              getStreamingDetectIntentMethod(),
               asyncBidiStreamingCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2.StreamingDetectIntentRequest,
@@ -258,11 +257,7 @@ public final class SessionsGrpc {
    * user intent and respond.
    * </pre>
    */
-  public static final class SessionsStub extends io.grpc.stub.AbstractStub<SessionsStub> {
-    private SessionsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SessionsStub extends io.grpc.stub.AbstractAsyncStub<SessionsStub> {
     private SessionsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -287,7 +282,7 @@ public final class SessionsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2.DetectIntentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDetectIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDetectIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -307,7 +302,7 @@ public final class SessionsGrpc {
                     com.google.cloud.dialogflow.v2.StreamingDetectIntentResponse>
                 responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingDetectIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getStreamingDetectIntentMethod(), getCallOptions()),
           responseObserver);
     }
   }
@@ -323,11 +318,7 @@ public final class SessionsGrpc {
    * </pre>
    */
   public static final class SessionsBlockingStub
-      extends io.grpc.stub.AbstractStub<SessionsBlockingStub> {
-    private SessionsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SessionsBlockingStub> {
     private SessionsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -349,8 +340,7 @@ public final class SessionsGrpc {
      */
     public com.google.cloud.dialogflow.v2.DetectIntentResponse detectIntent(
         com.google.cloud.dialogflow.v2.DetectIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDetectIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDetectIntentMethod(), getCallOptions(), request);
     }
   }
 
@@ -365,11 +355,7 @@ public final class SessionsGrpc {
    * </pre>
    */
   public static final class SessionsFutureStub
-      extends io.grpc.stub.AbstractStub<SessionsFutureStub> {
-    private SessionsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SessionsFutureStub> {
     private SessionsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -393,7 +379,7 @@ public final class SessionsGrpc {
             com.google.cloud.dialogflow.v2.DetectIntentResponse>
         detectIntent(com.google.cloud.dialogflow.v2.DetectIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDetectIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDetectIntentMethod(), getCallOptions()), request);
     }
   }
 
@@ -491,8 +477,8 @@ public final class SessionsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SessionsFileDescriptorSupplier())
-                      .addMethod(getDetectIntentMethodHelper())
-                      .addMethod(getStreamingDetectIntentMethodHelper())
+                      .addMethod(getDetectIntentMethod())
+                      .addMethod(getStreamingDetectIntentMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dialogflow-v2beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.0.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/dialogflow/v2beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/AgentsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/AgentsGrpc.java
@@ -52,7 +52,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/agent.proto")
 public final class AgentsGrpc {
 
@@ -61,30 +61,20 @@ public final class AgentsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.Agents";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
-          com.google.cloud.dialogflow.v2beta1.Agent>
-      METHOD_GET_AGENT = getGetAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
           com.google.cloud.dialogflow.v2beta1.Agent>
       getGetAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetAgentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Agent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
           com.google.cloud.dialogflow.v2beta1.Agent>
       getGetAgentMethod() {
-    return getGetAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
-          com.google.cloud.dialogflow.v2beta1.Agent>
-      getGetAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
             com.google.cloud.dialogflow.v2beta1.Agent>
@@ -99,9 +89,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Agent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "GetAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -118,30 +106,20 @@ public final class AgentsGrpc {
     return getGetAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
-          com.google.cloud.dialogflow.v2beta1.Agent>
-      METHOD_SET_AGENT = getSetAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
           com.google.cloud.dialogflow.v2beta1.Agent>
       getSetAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.SetAgentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Agent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
           com.google.cloud.dialogflow.v2beta1.Agent>
       getSetAgentMethod() {
-    return getSetAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
-          com.google.cloud.dialogflow.v2beta1.Agent>
-      getSetAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
             com.google.cloud.dialogflow.v2beta1.Agent>
@@ -156,9 +134,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Agent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "SetAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -175,26 +151,18 @@ public final class AgentsGrpc {
     return getSetAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_AGENT = getDeleteAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest, com.google.protobuf.Empty>
       getDeleteAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest, com.google.protobuf.Empty>
       getDeleteAgentMethod() {
-    return getDeleteAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest, com.google.protobuf.Empty>
-      getDeleteAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest, com.google.protobuf.Empty>
         getDeleteAgentMethod;
@@ -208,9 +176,7 @@ public final class AgentsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "DeleteAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -227,30 +193,20 @@ public final class AgentsGrpc {
     return getDeleteAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSearchAgentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
-          com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
-      METHOD_SEARCH_AGENTS = getSearchAgentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
           com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
       getSearchAgentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SearchAgents",
+      requestType = com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
           com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
       getSearchAgentsMethod() {
-    return getSearchAgentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
-          com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
-      getSearchAgentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
             com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
@@ -265,9 +221,7 @@ public final class AgentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "SearchAgents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SearchAgents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -285,26 +239,18 @@ public final class AgentsGrpc {
     return getSearchAgentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTrainAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.TrainAgentRequest, com.google.longrunning.Operation>
-      METHOD_TRAIN_AGENT = getTrainAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.TrainAgentRequest, com.google.longrunning.Operation>
       getTrainAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TrainAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.TrainAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.TrainAgentRequest, com.google.longrunning.Operation>
       getTrainAgentMethod() {
-    return getTrainAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.TrainAgentRequest, com.google.longrunning.Operation>
-      getTrainAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.TrainAgentRequest, com.google.longrunning.Operation>
         getTrainAgentMethod;
@@ -318,9 +264,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "TrainAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TrainAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -337,26 +281,18 @@ public final class AgentsGrpc {
     return getTrainAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ExportAgentRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_AGENT = getExportAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ExportAgentRequest, com.google.longrunning.Operation>
       getExportAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.ExportAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ExportAgentRequest, com.google.longrunning.Operation>
       getExportAgentMethod() {
-    return getExportAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ExportAgentRequest, com.google.longrunning.Operation>
-      getExportAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ExportAgentRequest,
             com.google.longrunning.Operation>
@@ -371,9 +307,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "ExportAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -390,26 +324,18 @@ public final class AgentsGrpc {
     return getExportAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ImportAgentRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_AGENT = getImportAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ImportAgentRequest, com.google.longrunning.Operation>
       getImportAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.ImportAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ImportAgentRequest, com.google.longrunning.Operation>
       getImportAgentMethod() {
-    return getImportAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ImportAgentRequest, com.google.longrunning.Operation>
-      getImportAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ImportAgentRequest,
             com.google.longrunning.Operation>
@@ -424,9 +350,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "ImportAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -443,26 +367,18 @@ public final class AgentsGrpc {
     return getImportAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRestoreAgentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest, com.google.longrunning.Operation>
-      METHOD_RESTORE_AGENT = getRestoreAgentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest, com.google.longrunning.Operation>
       getRestoreAgentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RestoreAgent",
+      requestType = com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest, com.google.longrunning.Operation>
       getRestoreAgentMethod() {
-    return getRestoreAgentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest, com.google.longrunning.Operation>
-      getRestoreAgentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest,
             com.google.longrunning.Operation>
@@ -477,9 +393,7 @@ public final class AgentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "RestoreAgent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RestoreAgent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -496,30 +410,20 @@ public final class AgentsGrpc {
     return getRestoreAgentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetValidationResultMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
-          com.google.cloud.dialogflow.v2beta1.ValidationResult>
-      METHOD_GET_VALIDATION_RESULT = getGetValidationResultMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
           com.google.cloud.dialogflow.v2beta1.ValidationResult>
       getGetValidationResultMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetValidationResult",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ValidationResult.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
           com.google.cloud.dialogflow.v2beta1.ValidationResult>
       getGetValidationResultMethod() {
-    return getGetValidationResultMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
-          com.google.cloud.dialogflow.v2beta1.ValidationResult>
-      getGetValidationResultMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
             com.google.cloud.dialogflow.v2beta1.ValidationResult>
@@ -535,8 +439,7 @@ public final class AgentsGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Agents", "GetValidationResult"))
+                          generateFullMethodName(SERVICE_NAME, "GetValidationResult"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -557,19 +460,42 @@ public final class AgentsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AgentsStub newStub(io.grpc.Channel channel) {
-    return new AgentsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsStub>() {
+          @java.lang.Override
+          public AgentsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsStub(channel, callOptions);
+          }
+        };
+    return AgentsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AgentsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AgentsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsBlockingStub>() {
+          @java.lang.Override
+          public AgentsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsBlockingStub(channel, callOptions);
+          }
+        };
+    return AgentsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AgentsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AgentsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AgentsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AgentsFutureStub>() {
+          @java.lang.Override
+          public AgentsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AgentsFutureStub(channel, callOptions);
+          }
+        };
+    return AgentsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -613,7 +539,7 @@ public final class AgentsGrpc {
     public void getAgent(
         com.google.cloud.dialogflow.v2beta1.GetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Agent> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAgentMethod(), responseObserver);
     }
 
     /**
@@ -626,7 +552,7 @@ public final class AgentsGrpc {
     public void setAgent(
         com.google.cloud.dialogflow.v2beta1.SetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Agent> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetAgentMethod(), responseObserver);
     }
 
     /**
@@ -639,7 +565,7 @@ public final class AgentsGrpc {
     public void deleteAgent(
         com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAgentMethod(), responseObserver);
     }
 
     /**
@@ -658,7 +584,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSearchAgentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSearchAgentsMethod(), responseObserver);
     }
 
     /**
@@ -672,7 +598,7 @@ public final class AgentsGrpc {
     public void trainAgent(
         com.google.cloud.dialogflow.v2beta1.TrainAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getTrainAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTrainAgentMethod(), responseObserver);
     }
 
     /**
@@ -686,7 +612,7 @@ public final class AgentsGrpc {
     public void exportAgent(
         com.google.cloud.dialogflow.v2beta1.ExportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportAgentMethod(), responseObserver);
     }
 
     /**
@@ -703,7 +629,7 @@ public final class AgentsGrpc {
     public void importAgent(
         com.google.cloud.dialogflow.v2beta1.ImportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportAgentMethod(), responseObserver);
     }
 
     /**
@@ -719,7 +645,7 @@ public final class AgentsGrpc {
     public void restoreAgent(
         com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getRestoreAgentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRestoreAgentMethod(), responseObserver);
     }
 
     /**
@@ -734,63 +660,63 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ValidationResult>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetValidationResultMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetValidationResultMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getGetAgentMethodHelper(),
+              getGetAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetAgentRequest,
                       com.google.cloud.dialogflow.v2beta1.Agent>(this, METHODID_GET_AGENT)))
           .addMethod(
-              getSetAgentMethodHelper(),
+              getSetAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.SetAgentRequest,
                       com.google.cloud.dialogflow.v2beta1.Agent>(this, METHODID_SET_AGENT)))
           .addMethod(
-              getDeleteAgentMethodHelper(),
+              getDeleteAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_AGENT)))
           .addMethod(
-              getSearchAgentsMethodHelper(),
+              getSearchAgentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest,
                       com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>(
                       this, METHODID_SEARCH_AGENTS)))
           .addMethod(
-              getTrainAgentMethodHelper(),
+              getTrainAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.TrainAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_TRAIN_AGENT)))
           .addMethod(
-              getExportAgentMethodHelper(),
+              getExportAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ExportAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_AGENT)))
           .addMethod(
-              getImportAgentMethodHelper(),
+              getImportAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ImportAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_AGENT)))
           .addMethod(
-              getRestoreAgentMethodHelper(),
+              getRestoreAgentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest,
                       com.google.longrunning.Operation>(this, METHODID_RESTORE_AGENT)))
           .addMethod(
-              getGetValidationResultMethodHelper(),
+              getGetValidationResultMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest,
@@ -829,11 +755,7 @@ public final class AgentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
    * </pre>
    */
-  public static final class AgentsStub extends io.grpc.stub.AbstractStub<AgentsStub> {
-    private AgentsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AgentsStub extends io.grpc.stub.AbstractAsyncStub<AgentsStub> {
     private AgentsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -854,9 +776,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.GetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Agent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -870,9 +790,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.SetAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Agent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getSetAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -886,7 +804,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -908,7 +826,7 @@ public final class AgentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSearchAgentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSearchAgentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -925,9 +843,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.TrainAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTrainAgentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getTrainAgentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -942,7 +858,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.ExportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -962,7 +878,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.ImportAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -981,7 +897,7 @@ public final class AgentsGrpc {
         com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRestoreAgentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRestoreAgentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -999,7 +915,7 @@ public final class AgentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ValidationResult>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetValidationResultMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetValidationResultMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1035,11 +951,7 @@ public final class AgentsGrpc {
    * </pre>
    */
   public static final class AgentsBlockingStub
-      extends io.grpc.stub.AbstractStub<AgentsBlockingStub> {
-    private AgentsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AgentsBlockingStub> {
     private AgentsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1058,7 +970,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Agent getAgent(
         com.google.cloud.dialogflow.v2beta1.GetAgentRequest request) {
-      return blockingUnaryCall(getChannel(), getGetAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1070,7 +982,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Agent setAgent(
         com.google.cloud.dialogflow.v2beta1.SetAgentRequest request) {
-      return blockingUnaryCall(getChannel(), getSetAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1082,8 +994,7 @@ public final class AgentsGrpc {
      */
     public com.google.protobuf.Empty deleteAgent(
         com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1100,8 +1011,7 @@ public final class AgentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse searchAgents(
         com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSearchAgentsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSearchAgentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1114,8 +1024,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation trainAgent(
         com.google.cloud.dialogflow.v2beta1.TrainAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getTrainAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getTrainAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1128,8 +1037,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation exportAgent(
         com.google.cloud.dialogflow.v2beta1.ExportAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1145,8 +1053,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation importAgent(
         com.google.cloud.dialogflow.v2beta1.ImportAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1161,8 +1068,7 @@ public final class AgentsGrpc {
      */
     public com.google.longrunning.Operation restoreAgent(
         com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getRestoreAgentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getRestoreAgentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1176,7 +1082,7 @@ public final class AgentsGrpc {
     public com.google.cloud.dialogflow.v2beta1.ValidationResult getValidationResult(
         com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetValidationResultMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetValidationResultMethod(), getCallOptions(), request);
     }
   }
 
@@ -1209,11 +1115,8 @@ public final class AgentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/agents-overview).
    * </pre>
    */
-  public static final class AgentsFutureStub extends io.grpc.stub.AbstractStub<AgentsFutureStub> {
-    private AgentsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AgentsFutureStub
+      extends io.grpc.stub.AbstractFutureStub<AgentsFutureStub> {
     private AgentsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1233,8 +1136,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.dialogflow.v2beta1.Agent>
         getAgent(com.google.cloud.dialogflow.v2beta1.GetAgentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetAgentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1247,8 +1149,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.dialogflow.v2beta1.Agent>
         setAgent(com.google.cloud.dialogflow.v2beta1.SetAgentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getSetAgentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getSetAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1261,7 +1162,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteAgent(com.google.cloud.dialogflow.v2beta1.DeleteAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1280,7 +1181,7 @@ public final class AgentsGrpc {
             com.google.cloud.dialogflow.v2beta1.SearchAgentsResponse>
         searchAgents(com.google.cloud.dialogflow.v2beta1.SearchAgentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSearchAgentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSearchAgentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1294,7 +1195,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         trainAgent(com.google.cloud.dialogflow.v2beta1.TrainAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTrainAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTrainAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1308,7 +1209,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportAgent(com.google.cloud.dialogflow.v2beta1.ExportAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1325,7 +1226,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importAgent(com.google.cloud.dialogflow.v2beta1.ImportAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1341,7 +1242,7 @@ public final class AgentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         restoreAgent(com.google.cloud.dialogflow.v2beta1.RestoreAgentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRestoreAgentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRestoreAgentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1357,7 +1258,7 @@ public final class AgentsGrpc {
         getValidationResult(
             com.google.cloud.dialogflow.v2beta1.GetValidationResultRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetValidationResultMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetValidationResultMethod(), getCallOptions()), request);
     }
   }
 
@@ -1500,15 +1401,15 @@ public final class AgentsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AgentsFileDescriptorSupplier())
-                      .addMethod(getGetAgentMethodHelper())
-                      .addMethod(getSetAgentMethodHelper())
-                      .addMethod(getDeleteAgentMethodHelper())
-                      .addMethod(getSearchAgentsMethodHelper())
-                      .addMethod(getTrainAgentMethodHelper())
-                      .addMethod(getExportAgentMethodHelper())
-                      .addMethod(getImportAgentMethodHelper())
-                      .addMethod(getRestoreAgentMethodHelper())
-                      .addMethod(getGetValidationResultMethodHelper())
+                      .addMethod(getGetAgentMethod())
+                      .addMethod(getSetAgentMethod())
+                      .addMethod(getDeleteAgentMethod())
+                      .addMethod(getSearchAgentsMethod())
+                      .addMethod(getTrainAgentMethod())
+                      .addMethod(getExportAgentMethod())
+                      .addMethod(getImportAgentMethod())
+                      .addMethod(getRestoreAgentMethod())
+                      .addMethod(getGetValidationResultMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/ContextsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/ContextsGrpc.java
@@ -45,7 +45,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/context.proto")
 public final class ContextsGrpc {
 
@@ -54,30 +54,20 @@ public final class ContextsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.Contexts";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListContextsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
-      METHOD_LIST_CONTEXTS = getListContextsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
           com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
       getListContextsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListContexts",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListContextsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListContextsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
           com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
       getListContextsMethod() {
-    return getListContextsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
-      getListContextsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
             com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
@@ -92,9 +82,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "ListContexts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListContexts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -112,30 +100,20 @@ public final class ContextsGrpc {
     return getListContextsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      METHOD_GET_CONTEXT = getGetContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getGetContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetContext",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getGetContextMethod() {
-    return getGetContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      getGetContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetContextRequest,
             com.google.cloud.dialogflow.v2beta1.Context>
@@ -150,9 +128,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "GetContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -169,30 +145,20 @@ public final class ContextsGrpc {
     return getGetContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      METHOD_CREATE_CONTEXT = getCreateContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getCreateContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateContext",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getCreateContextMethod() {
-    return getCreateContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      getCreateContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
             com.google.cloud.dialogflow.v2beta1.Context>
@@ -207,9 +173,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "CreateContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -226,30 +190,20 @@ public final class ContextsGrpc {
     return getCreateContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      METHOD_UPDATE_CONTEXT = getUpdateContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getUpdateContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateContext",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateContextRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Context.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
           com.google.cloud.dialogflow.v2beta1.Context>
       getUpdateContextMethod() {
-    return getUpdateContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
-          com.google.cloud.dialogflow.v2beta1.Context>
-      getUpdateContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
             com.google.cloud.dialogflow.v2beta1.Context>
@@ -264,9 +218,7 @@ public final class ContextsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Context>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "UpdateContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -283,26 +235,18 @@ public final class ContextsGrpc {
     return getUpdateContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteContextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteContextRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_CONTEXT = getDeleteContextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteContextRequest, com.google.protobuf.Empty>
       getDeleteContextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteContext",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteContextRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteContextRequest, com.google.protobuf.Empty>
       getDeleteContextMethod() {
-    return getDeleteContextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteContextRequest, com.google.protobuf.Empty>
-      getDeleteContextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteContextRequest, com.google.protobuf.Empty>
         getDeleteContextMethod;
@@ -316,9 +260,7 @@ public final class ContextsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "DeleteContext"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteContext"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -335,26 +277,18 @@ public final class ContextsGrpc {
     return getDeleteContextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAllContextsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ALL_CONTEXTS = getDeleteAllContextsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest, com.google.protobuf.Empty>
       getDeleteAllContextsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAllContexts",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest, com.google.protobuf.Empty>
       getDeleteAllContextsMethod() {
-    return getDeleteAllContextsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest, com.google.protobuf.Empty>
-      getDeleteAllContextsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest, com.google.protobuf.Empty>
         getDeleteAllContextsMethod;
@@ -368,9 +302,7 @@ public final class ContextsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Contexts", "DeleteAllContexts"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteAllContexts"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -390,19 +322,42 @@ public final class ContextsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ContextsStub newStub(io.grpc.Channel channel) {
-    return new ContextsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsStub>() {
+          @java.lang.Override
+          public ContextsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsStub(channel, callOptions);
+          }
+        };
+    return ContextsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ContextsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ContextsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsBlockingStub>() {
+          @java.lang.Override
+          public ContextsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsBlockingStub(channel, callOptions);
+          }
+        };
+    return ContextsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ContextsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ContextsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ContextsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ContextsFutureStub>() {
+          @java.lang.Override
+          public ContextsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ContextsFutureStub(channel, callOptions);
+          }
+        };
+    return ContextsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -440,7 +395,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.ListContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListContextsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListContextsMethod(), responseObserver);
     }
 
     /**
@@ -453,7 +408,7 @@ public final class ContextsGrpc {
     public void getContext(
         com.google.cloud.dialogflow.v2beta1.GetContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetContextMethod(), responseObserver);
     }
 
     /**
@@ -467,7 +422,7 @@ public final class ContextsGrpc {
     public void createContext(
         com.google.cloud.dialogflow.v2beta1.CreateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateContextMethod(), responseObserver);
     }
 
     /**
@@ -480,7 +435,7 @@ public final class ContextsGrpc {
     public void updateContext(
         com.google.cloud.dialogflow.v2beta1.UpdateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateContextMethod(), responseObserver);
     }
 
     /**
@@ -493,7 +448,7 @@ public final class ContextsGrpc {
     public void deleteContext(
         com.google.cloud.dialogflow.v2beta1.DeleteContextRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteContextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteContextMethod(), responseObserver);
     }
 
     /**
@@ -506,45 +461,45 @@ public final class ContextsGrpc {
     public void deleteAllContexts(
         com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAllContextsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAllContextsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListContextsMethodHelper(),
+              getListContextsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListContextsRequest,
                       com.google.cloud.dialogflow.v2beta1.ListContextsResponse>(
                       this, METHODID_LIST_CONTEXTS)))
           .addMethod(
-              getGetContextMethodHelper(),
+              getGetContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetContextRequest,
                       com.google.cloud.dialogflow.v2beta1.Context>(this, METHODID_GET_CONTEXT)))
           .addMethod(
-              getCreateContextMethodHelper(),
+              getCreateContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateContextRequest,
                       com.google.cloud.dialogflow.v2beta1.Context>(this, METHODID_CREATE_CONTEXT)))
           .addMethod(
-              getUpdateContextMethodHelper(),
+              getUpdateContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateContextRequest,
                       com.google.cloud.dialogflow.v2beta1.Context>(this, METHODID_UPDATE_CONTEXT)))
           .addMethod(
-              getDeleteContextMethodHelper(),
+              getDeleteContextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteContextRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_CONTEXT)))
           .addMethod(
-              getDeleteAllContextsMethodHelper(),
+              getDeleteAllContextsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest,
@@ -575,11 +530,7 @@ public final class ContextsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/contexts-overview).
    * </pre>
    */
-  public static final class ContextsStub extends io.grpc.stub.AbstractStub<ContextsStub> {
-    private ContextsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class ContextsStub extends io.grpc.stub.AbstractAsyncStub<ContextsStub> {
     private ContextsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -601,7 +552,7 @@ public final class ContextsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListContextsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListContextsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -617,9 +568,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.GetContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetContextMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetContextMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -634,7 +583,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -650,7 +599,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateContextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Context> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -666,7 +615,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteContextRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteContextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteContextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -682,7 +631,7 @@ public final class ContextsGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAllContextsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAllContextsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -711,11 +660,7 @@ public final class ContextsGrpc {
    * </pre>
    */
   public static final class ContextsBlockingStub
-      extends io.grpc.stub.AbstractStub<ContextsBlockingStub> {
-    private ContextsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ContextsBlockingStub> {
     private ContextsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -734,8 +679,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.ListContextsResponse listContexts(
         com.google.cloud.dialogflow.v2beta1.ListContextsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListContextsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListContextsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -747,8 +691,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Context getContext(
         com.google.cloud.dialogflow.v2beta1.GetContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -761,8 +704,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Context createContext(
         com.google.cloud.dialogflow.v2beta1.CreateContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -774,8 +716,7 @@ public final class ContextsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Context updateContext(
         com.google.cloud.dialogflow.v2beta1.UpdateContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -787,8 +728,7 @@ public final class ContextsGrpc {
      */
     public com.google.protobuf.Empty deleteContext(
         com.google.cloud.dialogflow.v2beta1.DeleteContextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteContextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteContextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -801,7 +741,7 @@ public final class ContextsGrpc {
     public com.google.protobuf.Empty deleteAllContexts(
         com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteAllContextsMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteAllContextsMethod(), getCallOptions(), request);
     }
   }
 
@@ -828,11 +768,7 @@ public final class ContextsGrpc {
    * </pre>
    */
   public static final class ContextsFutureStub
-      extends io.grpc.stub.AbstractStub<ContextsFutureStub> {
-    private ContextsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ContextsFutureStub> {
     private ContextsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -853,7 +789,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2beta1.ListContextsResponse>
         listContexts(com.google.cloud.dialogflow.v2beta1.ListContextsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListContextsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListContextsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -867,7 +803,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2beta1.Context>
         getContext(com.google.cloud.dialogflow.v2beta1.GetContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -882,7 +818,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2beta1.Context>
         createContext(com.google.cloud.dialogflow.v2beta1.CreateContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -896,7 +832,7 @@ public final class ContextsGrpc {
             com.google.cloud.dialogflow.v2beta1.Context>
         updateContext(com.google.cloud.dialogflow.v2beta1.UpdateContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -909,7 +845,7 @@ public final class ContextsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteContext(com.google.cloud.dialogflow.v2beta1.DeleteContextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteContextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteContextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -922,7 +858,7 @@ public final class ContextsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteAllContexts(com.google.cloud.dialogflow.v2beta1.DeleteAllContextsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAllContextsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteAllContextsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1047,12 +983,12 @@ public final class ContextsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ContextsFileDescriptorSupplier())
-                      .addMethod(getListContextsMethodHelper())
-                      .addMethod(getGetContextMethodHelper())
-                      .addMethod(getCreateContextMethodHelper())
-                      .addMethod(getUpdateContextMethodHelper())
-                      .addMethod(getDeleteContextMethodHelper())
-                      .addMethod(getDeleteAllContextsMethodHelper())
+                      .addMethod(getListContextsMethod())
+                      .addMethod(getGetContextMethod())
+                      .addMethod(getCreateContextMethod())
+                      .addMethod(getUpdateContextMethod())
+                      .addMethod(getDeleteContextMethod())
+                      .addMethod(getDeleteAllContextsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/DocumentsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/DocumentsGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/document.proto")
 public final class DocumentsGrpc {
 
@@ -39,30 +39,20 @@ public final class DocumentsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.Documents";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListDocumentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
-      METHOD_LIST_DOCUMENTS = getListDocumentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
           com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
       getListDocumentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListDocuments",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
           com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
       getListDocumentsMethod() {
-    return getListDocumentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
-      getListDocumentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
             com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
@@ -77,9 +67,7 @@ public final class DocumentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "ListDocuments"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListDocuments"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -97,30 +85,20 @@ public final class DocumentsGrpc {
     return getListDocumentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetDocumentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
-          com.google.cloud.dialogflow.v2beta1.Document>
-      METHOD_GET_DOCUMENT = getGetDocumentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
           com.google.cloud.dialogflow.v2beta1.Document>
       getGetDocumentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetDocument",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetDocumentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Document.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
           com.google.cloud.dialogflow.v2beta1.Document>
       getGetDocumentMethod() {
-    return getGetDocumentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
-          com.google.cloud.dialogflow.v2beta1.Document>
-      getGetDocumentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
             com.google.cloud.dialogflow.v2beta1.Document>
@@ -135,9 +113,7 @@ public final class DocumentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Document>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "GetDocument"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetDocument"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -154,30 +130,20 @@ public final class DocumentsGrpc {
     return getGetDocumentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateDocumentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
-          com.google.longrunning.Operation>
-      METHOD_CREATE_DOCUMENT = getCreateDocumentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
           com.google.longrunning.Operation>
       getCreateDocumentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateDocument",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
           com.google.longrunning.Operation>
       getCreateDocumentMethod() {
-    return getCreateDocumentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
-          com.google.longrunning.Operation>
-      getCreateDocumentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
             com.google.longrunning.Operation>
@@ -192,9 +158,7 @@ public final class DocumentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "CreateDocument"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateDocument"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -211,30 +175,20 @@ public final class DocumentsGrpc {
     return getCreateDocumentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteDocumentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
-          com.google.longrunning.Operation>
-      METHOD_DELETE_DOCUMENT = getDeleteDocumentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
           com.google.longrunning.Operation>
       getDeleteDocumentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteDocument",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
           com.google.longrunning.Operation>
       getDeleteDocumentMethod() {
-    return getDeleteDocumentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
-          com.google.longrunning.Operation>
-      getDeleteDocumentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
             com.google.longrunning.Operation>
@@ -249,9 +203,7 @@ public final class DocumentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "DeleteDocument"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteDocument"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -268,30 +220,20 @@ public final class DocumentsGrpc {
     return getDeleteDocumentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateDocumentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
-          com.google.longrunning.Operation>
-      METHOD_UPDATE_DOCUMENT = getUpdateDocumentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
           com.google.longrunning.Operation>
       getUpdateDocumentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateDocument",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
           com.google.longrunning.Operation>
       getUpdateDocumentMethod() {
-    return getUpdateDocumentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
-          com.google.longrunning.Operation>
-      getUpdateDocumentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
             com.google.longrunning.Operation>
@@ -306,9 +248,7 @@ public final class DocumentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "UpdateDocument"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateDocument"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -325,30 +265,20 @@ public final class DocumentsGrpc {
     return getUpdateDocumentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getReloadDocumentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
-          com.google.longrunning.Operation>
-      METHOD_RELOAD_DOCUMENT = getReloadDocumentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
           com.google.longrunning.Operation>
       getReloadDocumentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ReloadDocument",
+      requestType = com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
           com.google.longrunning.Operation>
       getReloadDocumentMethod() {
-    return getReloadDocumentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
-          com.google.longrunning.Operation>
-      getReloadDocumentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
             com.google.longrunning.Operation>
@@ -363,9 +293,7 @@ public final class DocumentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Documents", "ReloadDocument"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ReloadDocument"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -384,19 +312,42 @@ public final class DocumentsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static DocumentsStub newStub(io.grpc.Channel channel) {
-    return new DocumentsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DocumentsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DocumentsStub>() {
+          @java.lang.Override
+          public DocumentsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DocumentsStub(channel, callOptions);
+          }
+        };
+    return DocumentsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static DocumentsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new DocumentsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DocumentsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DocumentsBlockingStub>() {
+          @java.lang.Override
+          public DocumentsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DocumentsBlockingStub(channel, callOptions);
+          }
+        };
+    return DocumentsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static DocumentsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new DocumentsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<DocumentsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<DocumentsFutureStub>() {
+          @java.lang.Override
+          public DocumentsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new DocumentsFutureStub(channel, callOptions);
+          }
+        };
+    return DocumentsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -421,7 +372,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListDocumentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListDocumentsMethod(), responseObserver);
     }
 
     /**
@@ -437,7 +388,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.GetDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Document>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetDocumentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetDocumentMethod(), responseObserver);
     }
 
     /**
@@ -454,7 +405,7 @@ public final class DocumentsGrpc {
     public void createDocument(
         com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateDocumentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateDocumentMethod(), responseObserver);
     }
 
     /**
@@ -471,7 +422,7 @@ public final class DocumentsGrpc {
     public void deleteDocument(
         com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteDocumentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteDocumentMethod(), responseObserver);
     }
 
     /**
@@ -488,7 +439,7 @@ public final class DocumentsGrpc {
     public void updateDocument(
         com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateDocumentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateDocumentMethod(), responseObserver);
     }
 
     /**
@@ -508,45 +459,45 @@ public final class DocumentsGrpc {
     public void reloadDocument(
         com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getReloadDocumentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getReloadDocumentMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListDocumentsMethodHelper(),
+              getListDocumentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest,
                       com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>(
                       this, METHODID_LIST_DOCUMENTS)))
           .addMethod(
-              getGetDocumentMethodHelper(),
+              getGetDocumentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetDocumentRequest,
                       com.google.cloud.dialogflow.v2beta1.Document>(this, METHODID_GET_DOCUMENT)))
           .addMethod(
-              getCreateDocumentMethodHelper(),
+              getCreateDocumentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_DOCUMENT)))
           .addMethod(
-              getDeleteDocumentMethodHelper(),
+              getDeleteDocumentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_DOCUMENT)))
           .addMethod(
-              getUpdateDocumentMethodHelper(),
+              getUpdateDocumentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPDATE_DOCUMENT)))
           .addMethod(
-              getReloadDocumentMethodHelper(),
+              getReloadDocumentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest,
@@ -562,11 +513,7 @@ public final class DocumentsGrpc {
    * Manages documents of a knowledge base.
    * </pre>
    */
-  public static final class DocumentsStub extends io.grpc.stub.AbstractStub<DocumentsStub> {
-    private DocumentsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class DocumentsStub extends io.grpc.stub.AbstractAsyncStub<DocumentsStub> {
     private DocumentsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -590,7 +537,7 @@ public final class DocumentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListDocumentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListDocumentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -609,7 +556,7 @@ public final class DocumentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Document>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetDocumentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetDocumentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -629,7 +576,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateDocumentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateDocumentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -649,7 +596,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteDocumentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteDocumentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -669,7 +616,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateDocumentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateDocumentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -692,7 +639,7 @@ public final class DocumentsGrpc {
         com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getReloadDocumentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getReloadDocumentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -706,11 +653,7 @@ public final class DocumentsGrpc {
    * </pre>
    */
   public static final class DocumentsBlockingStub
-      extends io.grpc.stub.AbstractStub<DocumentsBlockingStub> {
-    private DocumentsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<DocumentsBlockingStub> {
     private DocumentsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -732,8 +675,7 @@ public final class DocumentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse listDocuments(
         com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListDocumentsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListDocumentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -747,8 +689,7 @@ public final class DocumentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Document getDocument(
         com.google.cloud.dialogflow.v2beta1.GetDocumentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetDocumentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetDocumentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -764,8 +705,7 @@ public final class DocumentsGrpc {
      */
     public com.google.longrunning.Operation createDocument(
         com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateDocumentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateDocumentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -781,8 +721,7 @@ public final class DocumentsGrpc {
      */
     public com.google.longrunning.Operation deleteDocument(
         com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteDocumentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteDocumentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -798,8 +737,7 @@ public final class DocumentsGrpc {
      */
     public com.google.longrunning.Operation updateDocument(
         com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateDocumentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateDocumentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -818,8 +756,7 @@ public final class DocumentsGrpc {
      */
     public com.google.longrunning.Operation reloadDocument(
         com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getReloadDocumentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getReloadDocumentMethod(), getCallOptions(), request);
     }
   }
 
@@ -831,11 +768,7 @@ public final class DocumentsGrpc {
    * </pre>
    */
   public static final class DocumentsFutureStub
-      extends io.grpc.stub.AbstractStub<DocumentsFutureStub> {
-    private DocumentsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<DocumentsFutureStub> {
     private DocumentsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -858,7 +791,7 @@ public final class DocumentsGrpc {
             com.google.cloud.dialogflow.v2beta1.ListDocumentsResponse>
         listDocuments(com.google.cloud.dialogflow.v2beta1.ListDocumentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListDocumentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListDocumentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -874,7 +807,7 @@ public final class DocumentsGrpc {
             com.google.cloud.dialogflow.v2beta1.Document>
         getDocument(com.google.cloud.dialogflow.v2beta1.GetDocumentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetDocumentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetDocumentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -891,7 +824,7 @@ public final class DocumentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createDocument(com.google.cloud.dialogflow.v2beta1.CreateDocumentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateDocumentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateDocumentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -908,7 +841,7 @@ public final class DocumentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteDocument(com.google.cloud.dialogflow.v2beta1.DeleteDocumentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteDocumentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteDocumentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -925,7 +858,7 @@ public final class DocumentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         updateDocument(com.google.cloud.dialogflow.v2beta1.UpdateDocumentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateDocumentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateDocumentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -945,7 +878,7 @@ public final class DocumentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         reloadDocument(com.google.cloud.dialogflow.v2beta1.ReloadDocumentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getReloadDocumentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getReloadDocumentMethod(), getCallOptions()), request);
     }
   }
 
@@ -1070,12 +1003,12 @@ public final class DocumentsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new DocumentsFileDescriptorSupplier())
-                      .addMethod(getListDocumentsMethodHelper())
-                      .addMethod(getGetDocumentMethodHelper())
-                      .addMethod(getCreateDocumentMethodHelper())
-                      .addMethod(getDeleteDocumentMethodHelper())
-                      .addMethod(getUpdateDocumentMethodHelper())
-                      .addMethod(getReloadDocumentMethodHelper())
+                      .addMethod(getListDocumentsMethod())
+                      .addMethod(getGetDocumentMethod())
+                      .addMethod(getCreateDocumentMethod())
+                      .addMethod(getDeleteDocumentMethod())
+                      .addMethod(getUpdateDocumentMethod())
+                      .addMethod(getReloadDocumentMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/EntityTypesGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/EntityTypesGrpc.java
@@ -51,7 +51,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/entity_type.proto")
 public final class EntityTypesGrpc {
 
@@ -60,30 +60,20 @@ public final class EntityTypesGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.EntityTypes";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
-      METHOD_LIST_ENTITY_TYPES = getListEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
           com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
       getListEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
           com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
       getListEntityTypesMethod() {
-    return getListEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
-      getListEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
             com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
@@ -98,9 +88,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "ListEntityTypes"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -119,30 +107,20 @@ public final class EntityTypesGrpc {
     return getListEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      METHOD_GET_ENTITY_TYPE = getGetEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getGetEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getGetEntityTypeMethod() {
-    return getGetEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      getGetEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.EntityType>
@@ -157,9 +135,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2beta1.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "GetEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -176,30 +152,20 @@ public final class EntityTypesGrpc {
     return getGetEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      METHOD_CREATE_ENTITY_TYPE = getCreateEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getCreateEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getCreateEntityTypeMethod() {
-    return getCreateEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      getCreateEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.EntityType>
@@ -214,9 +180,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2beta1.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "CreateEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -234,30 +198,20 @@ public final class EntityTypesGrpc {
     return getCreateEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      METHOD_UPDATE_ENTITY_TYPE = getUpdateEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getUpdateEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.EntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.EntityType>
       getUpdateEntityTypeMethod() {
-    return getUpdateEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.EntityType>
-      getUpdateEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.EntityType>
@@ -272,9 +226,7 @@ public final class EntityTypesGrpc {
                           com.google.cloud.dialogflow.v2beta1.EntityType>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "UpdateEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -292,26 +244,18 @@ public final class EntityTypesGrpc {
     return getUpdateEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_ENTITY_TYPE = getDeleteEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest, com.google.protobuf.Empty>
       getDeleteEntityTypeMethod() {
-    return getDeleteEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest, com.google.protobuf.Empty>
-      getDeleteEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest, com.google.protobuf.Empty>
         getDeleteEntityTypeMethod;
@@ -325,9 +269,7 @@ public final class EntityTypesGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "DeleteEntityType"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -345,30 +287,20 @@ public final class EntityTypesGrpc {
     return getDeleteEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_ENTITY_TYPES = getBatchUpdateEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntityTypesMethod() {
-    return getBatchUpdateEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
             com.google.longrunning.Operation>
@@ -386,9 +318,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes",
-                              "BatchUpdateEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "BatchUpdateEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -406,30 +336,20 @@ public final class EntityTypesGrpc {
     return getBatchUpdateEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_ENTITY_TYPES = getBatchDeleteEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntityTypesMethod() {
-    return getBatchDeleteEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
             com.google.longrunning.Operation>
@@ -447,9 +367,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes",
-                              "BatchDeleteEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "BatchDeleteEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -467,30 +385,20 @@ public final class EntityTypesGrpc {
     return getBatchDeleteEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchCreateEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_CREATE_ENTITIES = getBatchCreateEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchCreateEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchCreateEntities",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchCreateEntitiesMethod() {
-    return getBatchCreateEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchCreateEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
             com.google.longrunning.Operation>
@@ -506,8 +414,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "BatchCreateEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchCreateEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -525,30 +432,20 @@ public final class EntityTypesGrpc {
     return getBatchCreateEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_ENTITIES = getBatchUpdateEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateEntities",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchUpdateEntitiesMethod() {
-    return getBatchUpdateEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
             com.google.longrunning.Operation>
@@ -564,8 +461,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "BatchUpdateEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchUpdateEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -583,30 +479,20 @@ public final class EntityTypesGrpc {
     return getBatchUpdateEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_ENTITIES = getBatchDeleteEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteEntities",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
           com.google.longrunning.Operation>
       getBatchDeleteEntitiesMethod() {
-    return getBatchDeleteEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
             com.google.longrunning.Operation>
@@ -622,8 +508,7 @@ public final class EntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.EntityTypes", "BatchDeleteEntities"))
+                          generateFullMethodName(SERVICE_NAME, "BatchDeleteEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -643,19 +528,42 @@ public final class EntityTypesGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static EntityTypesStub newStub(io.grpc.Channel channel) {
-    return new EntityTypesStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesStub>() {
+          @java.lang.Override
+          public EntityTypesStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesStub(channel, callOptions);
+          }
+        };
+    return EntityTypesStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static EntityTypesBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new EntityTypesBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesBlockingStub>() {
+          @java.lang.Override
+          public EntityTypesBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesBlockingStub(channel, callOptions);
+          }
+        };
+    return EntityTypesBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static EntityTypesFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new EntityTypesFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<EntityTypesFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<EntityTypesFutureStub>() {
+          @java.lang.Override
+          public EntityTypesFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new EntityTypesFutureStub(channel, callOptions);
+          }
+        };
+    return EntityTypesFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -699,7 +607,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -713,7 +621,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -727,7 +635,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -741,7 +649,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -754,7 +662,7 @@ public final class EntityTypesGrpc {
     public void deleteEntityType(
         com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -768,7 +676,7 @@ public final class EntityTypesGrpc {
     public void batchUpdateEntityTypes(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -782,7 +690,7 @@ public final class EntityTypesGrpc {
     public void batchDeleteEntityTypes(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -796,7 +704,7 @@ public final class EntityTypesGrpc {
     public void batchCreateEntities(
         com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchCreateEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchCreateEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -812,7 +720,7 @@ public final class EntityTypesGrpc {
     public void batchUpdateEntities(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -826,72 +734,72 @@ public final class EntityTypesGrpc {
     public void batchDeleteEntities(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteEntitiesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListEntityTypesMethodHelper(),
+              getListEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest,
                       com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>(
                       this, METHODID_LIST_ENTITY_TYPES)))
           .addMethod(
-              getGetEntityTypeMethodHelper(),
+              getGetEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.EntityType>(
                       this, METHODID_GET_ENTITY_TYPE)))
           .addMethod(
-              getCreateEntityTypeMethodHelper(),
+              getCreateEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.EntityType>(
                       this, METHODID_CREATE_ENTITY_TYPE)))
           .addMethod(
-              getUpdateEntityTypeMethodHelper(),
+              getUpdateEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.EntityType>(
                       this, METHODID_UPDATE_ENTITY_TYPE)))
           .addMethod(
-              getDeleteEntityTypeMethodHelper(),
+              getDeleteEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_ENTITY_TYPE)))
           .addMethod(
-              getBatchUpdateEntityTypesMethodHelper(),
+              getBatchUpdateEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_ENTITY_TYPES)))
           .addMethod(
-              getBatchDeleteEntityTypesMethodHelper(),
+              getBatchDeleteEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_DELETE_ENTITY_TYPES)))
           .addMethod(
-              getBatchCreateEntitiesMethodHelper(),
+              getBatchCreateEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_CREATE_ENTITIES)))
           .addMethod(
-              getBatchUpdateEntitiesMethodHelper(),
+              getBatchUpdateEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_ENTITIES)))
           .addMethod(
-              getBatchDeleteEntitiesMethodHelper(),
+              getBatchDeleteEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest,
@@ -928,11 +836,8 @@ public final class EntityTypesGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/entities-overview).
    * </pre>
    */
-  public static final class EntityTypesStub extends io.grpc.stub.AbstractStub<EntityTypesStub> {
-    private EntityTypesStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class EntityTypesStub
+      extends io.grpc.stub.AbstractAsyncStub<EntityTypesStub> {
     private EntityTypesStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -954,7 +859,7 @@ public final class EntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -971,7 +876,7 @@ public final class EntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -988,7 +893,7 @@ public final class EntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1005,7 +910,7 @@ public final class EntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.EntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1021,7 +926,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1038,7 +943,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1055,7 +960,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1072,7 +977,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchCreateEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchCreateEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1091,7 +996,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1108,7 +1013,7 @@ public final class EntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1143,11 +1048,7 @@ public final class EntityTypesGrpc {
    * </pre>
    */
   public static final class EntityTypesBlockingStub
-      extends io.grpc.stub.AbstractStub<EntityTypesBlockingStub> {
-    private EntityTypesBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<EntityTypesBlockingStub> {
     private EntityTypesBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1167,8 +1068,7 @@ public final class EntityTypesGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse listEntityTypes(
         com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListEntityTypesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1180,8 +1080,7 @@ public final class EntityTypesGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.EntityType getEntityType(
         com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetEntityTypeMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1194,7 +1093,7 @@ public final class EntityTypesGrpc {
     public com.google.cloud.dialogflow.v2beta1.EntityType createEntityType(
         com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1207,7 +1106,7 @@ public final class EntityTypesGrpc {
     public com.google.cloud.dialogflow.v2beta1.EntityType updateEntityType(
         com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1220,7 +1119,7 @@ public final class EntityTypesGrpc {
     public com.google.protobuf.Empty deleteEntityType(
         com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1234,7 +1133,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchUpdateEntityTypes(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1248,7 +1147,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchDeleteEntityTypes(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1262,7 +1161,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchCreateEntities(
         com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchCreateEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchCreateEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1278,7 +1177,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchUpdateEntities(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1292,7 +1191,7 @@ public final class EntityTypesGrpc {
     public com.google.longrunning.Operation batchDeleteEntities(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteEntitiesMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteEntitiesMethod(), getCallOptions(), request);
     }
   }
 
@@ -1325,11 +1224,7 @@ public final class EntityTypesGrpc {
    * </pre>
    */
   public static final class EntityTypesFutureStub
-      extends io.grpc.stub.AbstractStub<EntityTypesFutureStub> {
-    private EntityTypesFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<EntityTypesFutureStub> {
     private EntityTypesFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1351,7 +1246,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2beta1.ListEntityTypesResponse>
         listEntityTypes(com.google.cloud.dialogflow.v2beta1.ListEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1365,7 +1260,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2beta1.EntityType>
         getEntityType(com.google.cloud.dialogflow.v2beta1.GetEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1379,7 +1274,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2beta1.EntityType>
         createEntityType(com.google.cloud.dialogflow.v2beta1.CreateEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1393,7 +1288,7 @@ public final class EntityTypesGrpc {
             com.google.cloud.dialogflow.v2beta1.EntityType>
         updateEntityType(com.google.cloud.dialogflow.v2beta1.UpdateEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1406,7 +1301,7 @@ public final class EntityTypesGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteEntityType(com.google.cloud.dialogflow.v2beta1.DeleteEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1421,7 +1316,7 @@ public final class EntityTypesGrpc {
         batchUpdateEntityTypes(
             com.google.cloud.dialogflow.v2beta1.BatchUpdateEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1436,7 +1331,7 @@ public final class EntityTypesGrpc {
         batchDeleteEntityTypes(
             com.google.cloud.dialogflow.v2beta1.BatchDeleteEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1451,7 +1346,7 @@ public final class EntityTypesGrpc {
         batchCreateEntities(
             com.google.cloud.dialogflow.v2beta1.BatchCreateEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchCreateEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchCreateEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1468,7 +1363,7 @@ public final class EntityTypesGrpc {
         batchUpdateEntities(
             com.google.cloud.dialogflow.v2beta1.BatchUpdateEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1483,7 +1378,7 @@ public final class EntityTypesGrpc {
         batchDeleteEntities(
             com.google.cloud.dialogflow.v2beta1.BatchDeleteEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteEntitiesMethod(), getCallOptions()), request);
     }
   }
 
@@ -1634,16 +1529,16 @@ public final class EntityTypesGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new EntityTypesFileDescriptorSupplier())
-                      .addMethod(getListEntityTypesMethodHelper())
-                      .addMethod(getGetEntityTypeMethodHelper())
-                      .addMethod(getCreateEntityTypeMethodHelper())
-                      .addMethod(getUpdateEntityTypeMethodHelper())
-                      .addMethod(getDeleteEntityTypeMethodHelper())
-                      .addMethod(getBatchUpdateEntityTypesMethodHelper())
-                      .addMethod(getBatchDeleteEntityTypesMethodHelper())
-                      .addMethod(getBatchCreateEntitiesMethodHelper())
-                      .addMethod(getBatchUpdateEntitiesMethodHelper())
-                      .addMethod(getBatchDeleteEntitiesMethodHelper())
+                      .addMethod(getListEntityTypesMethod())
+                      .addMethod(getGetEntityTypeMethod())
+                      .addMethod(getCreateEntityTypeMethod())
+                      .addMethod(getUpdateEntityTypeMethod())
+                      .addMethod(getDeleteEntityTypeMethod())
+                      .addMethod(getBatchUpdateEntityTypesMethod())
+                      .addMethod(getBatchDeleteEntityTypesMethod())
+                      .addMethod(getBatchCreateEntitiesMethod())
+                      .addMethod(getBatchUpdateEntitiesMethod())
+                      .addMethod(getBatchDeleteEntitiesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/IntentsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/IntentsGrpc.java
@@ -56,7 +56,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/intent.proto")
 public final class IntentsGrpc {
 
@@ -65,30 +65,20 @@ public final class IntentsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.Intents";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
-      METHOD_LIST_INTENTS = getListIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
           com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
       getListIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListIntents",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListIntentsRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListIntentsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
           com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
       getListIntentsMethod() {
-    return getListIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
-          com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
-      getListIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
             com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
@@ -103,9 +93,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "ListIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -123,30 +111,20 @@ public final class IntentsGrpc {
     return getListIntentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      METHOD_GET_INTENT = getGetIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getGetIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getGetIntentMethod() {
-    return getGetIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      getGetIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
             com.google.cloud.dialogflow.v2beta1.Intent>
@@ -161,9 +139,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "GetIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -180,30 +156,20 @@ public final class IntentsGrpc {
     return getGetIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      METHOD_CREATE_INTENT = getCreateIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getCreateIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getCreateIntentMethod() {
-    return getCreateIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      getCreateIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
             com.google.cloud.dialogflow.v2beta1.Intent>
@@ -218,9 +184,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "CreateIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -237,30 +201,20 @@ public final class IntentsGrpc {
     return getCreateIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      METHOD_UPDATE_INTENT = getUpdateIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getUpdateIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.Intent.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
           com.google.cloud.dialogflow.v2beta1.Intent>
       getUpdateIntentMethod() {
-    return getUpdateIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.Intent>
-      getUpdateIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
             com.google.cloud.dialogflow.v2beta1.Intent>
@@ -275,9 +229,7 @@ public final class IntentsGrpc {
                           com.google.cloud.dialogflow.v2beta1.Intent>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "UpdateIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -294,26 +246,18 @@ public final class IntentsGrpc {
     return getUpdateIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_INTENT = getDeleteIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest, com.google.protobuf.Empty>
       getDeleteIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest, com.google.protobuf.Empty>
       getDeleteIntentMethod() {
-    return getDeleteIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest, com.google.protobuf.Empty>
-      getDeleteIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest, com.google.protobuf.Empty>
         getDeleteIntentMethod;
@@ -327,9 +271,7 @@ public final class IntentsGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "DeleteIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -346,30 +288,20 @@ public final class IntentsGrpc {
     return getDeleteIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchUpdateIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_UPDATE_INTENTS = getBatchUpdateIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
           com.google.longrunning.Operation>
       getBatchUpdateIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchUpdateIntents",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
           com.google.longrunning.Operation>
       getBatchUpdateIntentsMethod() {
-    return getBatchUpdateIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
-          com.google.longrunning.Operation>
-      getBatchUpdateIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
             com.google.longrunning.Operation>
@@ -384,9 +316,7 @@ public final class IntentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "BatchUpdateIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchUpdateIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -404,30 +334,20 @@ public final class IntentsGrpc {
     return getBatchUpdateIntentsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchDeleteIntentsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
-          com.google.longrunning.Operation>
-      METHOD_BATCH_DELETE_INTENTS = getBatchDeleteIntentsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
           com.google.longrunning.Operation>
       getBatchDeleteIntentsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchDeleteIntents",
+      requestType = com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
           com.google.longrunning.Operation>
       getBatchDeleteIntentsMethod() {
-    return getBatchDeleteIntentsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
-          com.google.longrunning.Operation>
-      getBatchDeleteIntentsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
             com.google.longrunning.Operation>
@@ -442,9 +362,7 @@ public final class IntentsGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Intents", "BatchDeleteIntents"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchDeleteIntents"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -464,19 +382,42 @@ public final class IntentsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static IntentsStub newStub(io.grpc.Channel channel) {
-    return new IntentsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsStub>() {
+          @java.lang.Override
+          public IntentsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsStub(channel, callOptions);
+          }
+        };
+    return IntentsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static IntentsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new IntentsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsBlockingStub>() {
+          @java.lang.Override
+          public IntentsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsBlockingStub(channel, callOptions);
+          }
+        };
+    return IntentsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static IntentsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new IntentsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<IntentsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<IntentsFutureStub>() {
+          @java.lang.Override
+          public IntentsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new IntentsFutureStub(channel, callOptions);
+          }
+        };
+    return IntentsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -525,7 +466,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.ListIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListIntentsMethod(), responseObserver);
     }
 
     /**
@@ -538,7 +479,7 @@ public final class IntentsGrpc {
     public void getIntent(
         com.google.cloud.dialogflow.v2beta1.GetIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIntentMethod(), responseObserver);
     }
 
     /**
@@ -551,7 +492,7 @@ public final class IntentsGrpc {
     public void createIntent(
         com.google.cloud.dialogflow.v2beta1.CreateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateIntentMethod(), responseObserver);
     }
 
     /**
@@ -564,7 +505,7 @@ public final class IntentsGrpc {
     public void updateIntent(
         com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateIntentMethod(), responseObserver);
     }
 
     /**
@@ -577,7 +518,7 @@ public final class IntentsGrpc {
     public void deleteIntent(
         com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteIntentMethod(), responseObserver);
     }
 
     /**
@@ -591,7 +532,7 @@ public final class IntentsGrpc {
     public void batchUpdateIntents(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchUpdateIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchUpdateIntentsMethod(), responseObserver);
     }
 
     /**
@@ -605,51 +546,51 @@ public final class IntentsGrpc {
     public void batchDeleteIntents(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchDeleteIntentsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchDeleteIntentsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListIntentsMethodHelper(),
+              getListIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListIntentsRequest,
                       com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>(
                       this, METHODID_LIST_INTENTS)))
           .addMethod(
-              getGetIntentMethodHelper(),
+              getGetIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetIntentRequest,
                       com.google.cloud.dialogflow.v2beta1.Intent>(this, METHODID_GET_INTENT)))
           .addMethod(
-              getCreateIntentMethodHelper(),
+              getCreateIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateIntentRequest,
                       com.google.cloud.dialogflow.v2beta1.Intent>(this, METHODID_CREATE_INTENT)))
           .addMethod(
-              getUpdateIntentMethodHelper(),
+              getUpdateIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest,
                       com.google.cloud.dialogflow.v2beta1.Intent>(this, METHODID_UPDATE_INTENT)))
           .addMethod(
-              getDeleteIntentMethodHelper(),
+              getDeleteIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_INTENT)))
           .addMethod(
-              getBatchUpdateIntentsMethodHelper(),
+              getBatchUpdateIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest,
                       com.google.longrunning.Operation>(this, METHODID_BATCH_UPDATE_INTENTS)))
           .addMethod(
-              getBatchDeleteIntentsMethodHelper(),
+              getBatchDeleteIntentsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest,
@@ -691,11 +632,7 @@ public final class IntentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
    * </pre>
    */
-  public static final class IntentsStub extends io.grpc.stub.AbstractStub<IntentsStub> {
-    private IntentsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class IntentsStub extends io.grpc.stub.AbstractAsyncStub<IntentsStub> {
     private IntentsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -717,7 +654,7 @@ public final class IntentsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -733,9 +670,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.GetIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIntentMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetIntentMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -749,7 +684,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -765,7 +700,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.Intent> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -781,7 +716,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -798,7 +733,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchUpdateIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchUpdateIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -815,7 +750,7 @@ public final class IntentsGrpc {
         com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchDeleteIntentsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchDeleteIntentsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -855,11 +790,7 @@ public final class IntentsGrpc {
    * </pre>
    */
   public static final class IntentsBlockingStub
-      extends io.grpc.stub.AbstractStub<IntentsBlockingStub> {
-    private IntentsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<IntentsBlockingStub> {
     private IntentsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -878,8 +809,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.ListIntentsResponse listIntents(
         com.google.cloud.dialogflow.v2beta1.ListIntentsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListIntentsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListIntentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -891,7 +821,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Intent getIntent(
         com.google.cloud.dialogflow.v2beta1.GetIntentRequest request) {
-      return blockingUnaryCall(getChannel(), getGetIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -903,8 +833,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Intent createIntent(
         com.google.cloud.dialogflow.v2beta1.CreateIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -916,8 +845,7 @@ public final class IntentsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.Intent updateIntent(
         com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -929,8 +857,7 @@ public final class IntentsGrpc {
      */
     public com.google.protobuf.Empty deleteIntent(
         com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteIntentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -944,7 +871,7 @@ public final class IntentsGrpc {
     public com.google.longrunning.Operation batchUpdateIntents(
         com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchUpdateIntentsMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchUpdateIntentsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -958,7 +885,7 @@ public final class IntentsGrpc {
     public com.google.longrunning.Operation batchDeleteIntents(
         com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchDeleteIntentsMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchDeleteIntentsMethod(), getCallOptions(), request);
     }
   }
 
@@ -995,11 +922,8 @@ public final class IntentsGrpc {
    * documentation](https://cloud.google.com/dialogflow/docs/intents-overview).
    * </pre>
    */
-  public static final class IntentsFutureStub extends io.grpc.stub.AbstractStub<IntentsFutureStub> {
-    private IntentsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class IntentsFutureStub
+      extends io.grpc.stub.AbstractFutureStub<IntentsFutureStub> {
     private IntentsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1020,7 +944,7 @@ public final class IntentsGrpc {
             com.google.cloud.dialogflow.v2beta1.ListIntentsResponse>
         listIntents(com.google.cloud.dialogflow.v2beta1.ListIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListIntentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1033,8 +957,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.dialogflow.v2beta1.Intent>
         getIntent(com.google.cloud.dialogflow.v2beta1.GetIntentRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetIntentMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1048,7 +971,7 @@ public final class IntentsGrpc {
             com.google.cloud.dialogflow.v2beta1.Intent>
         createIntent(com.google.cloud.dialogflow.v2beta1.CreateIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1062,7 +985,7 @@ public final class IntentsGrpc {
             com.google.cloud.dialogflow.v2beta1.Intent>
         updateIntent(com.google.cloud.dialogflow.v2beta1.UpdateIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1075,7 +998,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteIntent(com.google.cloud.dialogflow.v2beta1.DeleteIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteIntentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1089,7 +1012,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchUpdateIntents(com.google.cloud.dialogflow.v2beta1.BatchUpdateIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchUpdateIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchUpdateIntentsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1103,7 +1026,7 @@ public final class IntentsGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchDeleteIntents(com.google.cloud.dialogflow.v2beta1.BatchDeleteIntentsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchDeleteIntentsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchDeleteIntentsMethod(), getCallOptions()), request);
     }
   }
 
@@ -1233,13 +1156,13 @@ public final class IntentsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new IntentsFileDescriptorSupplier())
-                      .addMethod(getListIntentsMethodHelper())
-                      .addMethod(getGetIntentMethodHelper())
-                      .addMethod(getCreateIntentMethodHelper())
-                      .addMethod(getUpdateIntentMethodHelper())
-                      .addMethod(getDeleteIntentMethodHelper())
-                      .addMethod(getBatchUpdateIntentsMethodHelper())
-                      .addMethod(getBatchDeleteIntentsMethodHelper())
+                      .addMethod(getListIntentsMethod())
+                      .addMethod(getGetIntentMethod())
+                      .addMethod(getCreateIntentMethod())
+                      .addMethod(getUpdateIntentMethod())
+                      .addMethod(getDeleteIntentMethod())
+                      .addMethod(getBatchUpdateIntentsMethod())
+                      .addMethod(getBatchDeleteIntentsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/KnowledgeBasesGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/KnowledgeBasesGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/knowledge_base.proto")
 public final class KnowledgeBasesGrpc {
 
@@ -40,30 +40,20 @@ public final class KnowledgeBasesGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.KnowledgeBases";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListKnowledgeBasesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
-      METHOD_LIST_KNOWLEDGE_BASES = getListKnowledgeBasesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
           com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
       getListKnowledgeBasesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListKnowledgeBases",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
           com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
       getListKnowledgeBasesMethod() {
-    return getListKnowledgeBasesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
-      getListKnowledgeBasesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
             com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
@@ -79,10 +69,7 @@ public final class KnowledgeBasesGrpc {
                           com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.KnowledgeBases",
-                              "ListKnowledgeBases"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListKnowledgeBases"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -101,30 +88,20 @@ public final class KnowledgeBasesGrpc {
     return getListKnowledgeBasesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetKnowledgeBaseMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      METHOD_GET_KNOWLEDGE_BASE = getGetKnowledgeBaseMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getGetKnowledgeBaseMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetKnowledgeBase",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.KnowledgeBase.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getGetKnowledgeBaseMethod() {
-    return getGetKnowledgeBaseMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      getGetKnowledgeBaseMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
             com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
@@ -139,9 +116,7 @@ public final class KnowledgeBasesGrpc {
                           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.KnowledgeBases", "GetKnowledgeBase"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetKnowledgeBase"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -160,30 +135,20 @@ public final class KnowledgeBasesGrpc {
     return getGetKnowledgeBaseMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateKnowledgeBaseMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      METHOD_CREATE_KNOWLEDGE_BASE = getCreateKnowledgeBaseMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getCreateKnowledgeBaseMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateKnowledgeBase",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.KnowledgeBase.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getCreateKnowledgeBaseMethod() {
-    return getCreateKnowledgeBaseMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      getCreateKnowledgeBaseMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
             com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
@@ -200,9 +165,7 @@ public final class KnowledgeBasesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.KnowledgeBases",
-                              "CreateKnowledgeBase"))
+                          generateFullMethodName(SERVICE_NAME, "CreateKnowledgeBase"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -221,26 +184,18 @@ public final class KnowledgeBasesGrpc {
     return getCreateKnowledgeBaseMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteKnowledgeBaseMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_KNOWLEDGE_BASE = getDeleteKnowledgeBaseMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest, com.google.protobuf.Empty>
       getDeleteKnowledgeBaseMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteKnowledgeBase",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest, com.google.protobuf.Empty>
       getDeleteKnowledgeBaseMethod() {
-    return getDeleteKnowledgeBaseMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest, com.google.protobuf.Empty>
-      getDeleteKnowledgeBaseMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest,
             com.google.protobuf.Empty>
@@ -257,9 +212,7 @@ public final class KnowledgeBasesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.KnowledgeBases",
-                              "DeleteKnowledgeBase"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteKnowledgeBase"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -277,30 +230,20 @@ public final class KnowledgeBasesGrpc {
     return getDeleteKnowledgeBaseMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateKnowledgeBaseMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      METHOD_UPDATE_KNOWLEDGE_BASE = getUpdateKnowledgeBaseMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getUpdateKnowledgeBaseMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateKnowledgeBase",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.KnowledgeBase.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
           com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
       getUpdateKnowledgeBaseMethod() {
-    return getUpdateKnowledgeBaseMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
-          com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
-      getUpdateKnowledgeBaseMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
             com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
@@ -317,9 +260,7 @@ public final class KnowledgeBasesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.KnowledgeBases",
-                              "UpdateKnowledgeBase"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateKnowledgeBase"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -340,19 +281,43 @@ public final class KnowledgeBasesGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static KnowledgeBasesStub newStub(io.grpc.Channel channel) {
-    return new KnowledgeBasesStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesStub>() {
+          @java.lang.Override
+          public KnowledgeBasesStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new KnowledgeBasesStub(channel, callOptions);
+          }
+        };
+    return KnowledgeBasesStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static KnowledgeBasesBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new KnowledgeBasesBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesBlockingStub>() {
+          @java.lang.Override
+          public KnowledgeBasesBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new KnowledgeBasesBlockingStub(channel, callOptions);
+          }
+        };
+    return KnowledgeBasesBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static KnowledgeBasesFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new KnowledgeBasesFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<KnowledgeBasesFutureStub>() {
+          @java.lang.Override
+          public KnowledgeBasesFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new KnowledgeBasesFutureStub(channel, callOptions);
+          }
+        };
+    return KnowledgeBasesFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -378,7 +343,7 @@ public final class KnowledgeBasesGrpc {
         com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListKnowledgeBasesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListKnowledgeBasesMethod(), responseObserver);
     }
 
     /**
@@ -394,7 +359,7 @@ public final class KnowledgeBasesGrpc {
         com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetKnowledgeBaseMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetKnowledgeBaseMethod(), responseObserver);
     }
 
     /**
@@ -410,7 +375,7 @@ public final class KnowledgeBasesGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateKnowledgeBaseMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateKnowledgeBaseMethod(), responseObserver);
     }
 
     /**
@@ -425,7 +390,7 @@ public final class KnowledgeBasesGrpc {
     public void deleteKnowledgeBase(
         com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteKnowledgeBaseMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteKnowledgeBaseMethod(), responseObserver);
     }
 
     /**
@@ -441,41 +406,41 @@ public final class KnowledgeBasesGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateKnowledgeBaseMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateKnowledgeBaseMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListKnowledgeBasesMethodHelper(),
+              getListKnowledgeBasesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest,
                       com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>(
                       this, METHODID_LIST_KNOWLEDGE_BASES)))
           .addMethod(
-              getGetKnowledgeBaseMethodHelper(),
+              getGetKnowledgeBaseMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest,
                       com.google.cloud.dialogflow.v2beta1.KnowledgeBase>(
                       this, METHODID_GET_KNOWLEDGE_BASE)))
           .addMethod(
-              getCreateKnowledgeBaseMethodHelper(),
+              getCreateKnowledgeBaseMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest,
                       com.google.cloud.dialogflow.v2beta1.KnowledgeBase>(
                       this, METHODID_CREATE_KNOWLEDGE_BASE)))
           .addMethod(
-              getDeleteKnowledgeBaseMethodHelper(),
+              getDeleteKnowledgeBaseMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_KNOWLEDGE_BASE)))
           .addMethod(
-              getUpdateKnowledgeBaseMethodHelper(),
+              getUpdateKnowledgeBaseMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest,
@@ -494,11 +459,7 @@ public final class KnowledgeBasesGrpc {
    * </pre>
    */
   public static final class KnowledgeBasesStub
-      extends io.grpc.stub.AbstractStub<KnowledgeBasesStub> {
-    private KnowledgeBasesStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<KnowledgeBasesStub> {
     private KnowledgeBasesStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -522,7 +483,7 @@ public final class KnowledgeBasesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListKnowledgeBasesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListKnowledgeBasesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -541,7 +502,7 @@ public final class KnowledgeBasesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetKnowledgeBaseMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetKnowledgeBaseMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -560,7 +521,7 @@ public final class KnowledgeBasesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateKnowledgeBaseMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateKnowledgeBaseMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -578,7 +539,7 @@ public final class KnowledgeBasesGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteKnowledgeBaseMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteKnowledgeBaseMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -597,7 +558,7 @@ public final class KnowledgeBasesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateKnowledgeBaseMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateKnowledgeBaseMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -612,11 +573,7 @@ public final class KnowledgeBasesGrpc {
    * </pre>
    */
   public static final class KnowledgeBasesBlockingStub
-      extends io.grpc.stub.AbstractStub<KnowledgeBasesBlockingStub> {
-    private KnowledgeBasesBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<KnowledgeBasesBlockingStub> {
     private KnowledgeBasesBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -639,7 +596,7 @@ public final class KnowledgeBasesGrpc {
     public com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse listKnowledgeBases(
         com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListKnowledgeBasesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListKnowledgeBasesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -654,7 +611,7 @@ public final class KnowledgeBasesGrpc {
     public com.google.cloud.dialogflow.v2beta1.KnowledgeBase getKnowledgeBase(
         com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetKnowledgeBaseMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetKnowledgeBaseMethod(), getCallOptions(), request);
     }
 
     /**
@@ -669,7 +626,7 @@ public final class KnowledgeBasesGrpc {
     public com.google.cloud.dialogflow.v2beta1.KnowledgeBase createKnowledgeBase(
         com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateKnowledgeBaseMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateKnowledgeBaseMethod(), getCallOptions(), request);
     }
 
     /**
@@ -684,7 +641,7 @@ public final class KnowledgeBasesGrpc {
     public com.google.protobuf.Empty deleteKnowledgeBase(
         com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteKnowledgeBaseMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteKnowledgeBaseMethod(), getCallOptions(), request);
     }
 
     /**
@@ -699,7 +656,7 @@ public final class KnowledgeBasesGrpc {
     public com.google.cloud.dialogflow.v2beta1.KnowledgeBase updateKnowledgeBase(
         com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateKnowledgeBaseMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateKnowledgeBaseMethod(), getCallOptions(), request);
     }
   }
 
@@ -712,11 +669,7 @@ public final class KnowledgeBasesGrpc {
    * </pre>
    */
   public static final class KnowledgeBasesFutureStub
-      extends io.grpc.stub.AbstractStub<KnowledgeBasesFutureStub> {
-    private KnowledgeBasesFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<KnowledgeBasesFutureStub> {
     private KnowledgeBasesFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -740,7 +693,7 @@ public final class KnowledgeBasesGrpc {
             com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesResponse>
         listKnowledgeBases(com.google.cloud.dialogflow.v2beta1.ListKnowledgeBasesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListKnowledgeBasesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListKnowledgeBasesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -756,7 +709,7 @@ public final class KnowledgeBasesGrpc {
             com.google.cloud.dialogflow.v2beta1.KnowledgeBase>
         getKnowledgeBase(com.google.cloud.dialogflow.v2beta1.GetKnowledgeBaseRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetKnowledgeBaseMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetKnowledgeBaseMethod(), getCallOptions()), request);
     }
 
     /**
@@ -773,7 +726,7 @@ public final class KnowledgeBasesGrpc {
         createKnowledgeBase(
             com.google.cloud.dialogflow.v2beta1.CreateKnowledgeBaseRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateKnowledgeBaseMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateKnowledgeBaseMethod(), getCallOptions()), request);
     }
 
     /**
@@ -789,7 +742,7 @@ public final class KnowledgeBasesGrpc {
         deleteKnowledgeBase(
             com.google.cloud.dialogflow.v2beta1.DeleteKnowledgeBaseRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteKnowledgeBaseMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteKnowledgeBaseMethod(), getCallOptions()), request);
     }
 
     /**
@@ -806,7 +759,7 @@ public final class KnowledgeBasesGrpc {
         updateKnowledgeBase(
             com.google.cloud.dialogflow.v2beta1.UpdateKnowledgeBaseRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateKnowledgeBaseMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateKnowledgeBaseMethod(), getCallOptions()), request);
     }
   }
 
@@ -927,11 +880,11 @@ public final class KnowledgeBasesGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new KnowledgeBasesFileDescriptorSupplier())
-                      .addMethod(getListKnowledgeBasesMethodHelper())
-                      .addMethod(getGetKnowledgeBaseMethodHelper())
-                      .addMethod(getCreateKnowledgeBaseMethodHelper())
-                      .addMethod(getDeleteKnowledgeBaseMethodHelper())
-                      .addMethod(getUpdateKnowledgeBaseMethodHelper())
+                      .addMethod(getListKnowledgeBasesMethod())
+                      .addMethod(getGetKnowledgeBaseMethod())
+                      .addMethod(getCreateKnowledgeBaseMethod())
+                      .addMethod(getDeleteKnowledgeBaseMethod())
+                      .addMethod(getUpdateKnowledgeBaseMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/SessionEntityTypesGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/SessionEntityTypesGrpc.java
@@ -43,7 +43,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/session_entity_type.proto")
 public final class SessionEntityTypesGrpc {
 
@@ -52,30 +52,20 @@ public final class SessionEntityTypesGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.SessionEntityTypes";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListSessionEntityTypesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
-      METHOD_LIST_SESSION_ENTITY_TYPES = getListSessionEntityTypesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
           com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
       getListSessionEntityTypesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListSessionEntityTypes",
+      requestType = com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
           com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
       getListSessionEntityTypesMethod() {
-    return getListSessionEntityTypesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
-          com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
-      getListSessionEntityTypesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
             com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
@@ -94,9 +84,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.SessionEntityTypes",
-                              "ListSessionEntityTypes"))
+                          generateFullMethodName(SERVICE_NAME, "ListSessionEntityTypes"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -115,30 +103,20 @@ public final class SessionEntityTypesGrpc {
     return getListSessionEntityTypesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      METHOD_GET_SESSION_ENTITY_TYPE = getGetSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getGetSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getGetSessionEntityTypeMethod() {
-    return getGetSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      getGetSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.SessionEntityType>
@@ -156,9 +134,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.SessionEntityTypes",
-                              "GetSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "GetSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -177,30 +153,20 @@ public final class SessionEntityTypesGrpc {
     return getGetSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      METHOD_CREATE_SESSION_ENTITY_TYPE = getCreateSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getCreateSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getCreateSessionEntityTypeMethod() {
-    return getCreateSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      getCreateSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.SessionEntityType>
@@ -219,9 +185,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.SessionEntityTypes",
-                              "CreateSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "CreateSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -240,30 +204,20 @@ public final class SessionEntityTypesGrpc {
     return getCreateSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      METHOD_UPDATE_SESSION_ENTITY_TYPE = getUpdateSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getUpdateSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.SessionEntityType.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
           com.google.cloud.dialogflow.v2beta1.SessionEntityType>
       getUpdateSessionEntityTypeMethod() {
-    return getUpdateSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
-          com.google.cloud.dialogflow.v2beta1.SessionEntityType>
-      getUpdateSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
             com.google.cloud.dialogflow.v2beta1.SessionEntityType>
@@ -282,9 +236,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.SessionEntityTypes",
-                              "UpdateSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -303,30 +255,20 @@ public final class SessionEntityTypesGrpc {
     return getUpdateSessionEntityTypeMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteSessionEntityTypeMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_SESSION_ENTITY_TYPE = getDeleteSessionEntityTypeMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
           com.google.protobuf.Empty>
       getDeleteSessionEntityTypeMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteSessionEntityType",
+      requestType = com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
           com.google.protobuf.Empty>
       getDeleteSessionEntityTypeMethod() {
-    return getDeleteSessionEntityTypeMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
-          com.google.protobuf.Empty>
-      getDeleteSessionEntityTypeMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
             com.google.protobuf.Empty>
@@ -345,9 +287,7 @@ public final class SessionEntityTypesGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.SessionEntityTypes",
-                              "DeleteSessionEntityType"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteSessionEntityType"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -367,19 +307,43 @@ public final class SessionEntityTypesGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SessionEntityTypesStub newStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesStub>() {
+          @java.lang.Override
+          public SessionEntityTypesStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SessionEntityTypesBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesBlockingStub>() {
+          @java.lang.Override
+          public SessionEntityTypesBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesBlockingStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SessionEntityTypesFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SessionEntityTypesFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionEntityTypesFutureStub>() {
+          @java.lang.Override
+          public SessionEntityTypesFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionEntityTypesFutureStub(channel, callOptions);
+          }
+        };
+    return SessionEntityTypesFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -419,7 +383,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListSessionEntityTypesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListSessionEntityTypesMethod(), responseObserver);
     }
 
     /**
@@ -436,7 +400,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -455,7 +419,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -472,7 +436,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSessionEntityTypeMethod(), responseObserver);
     }
 
     /**
@@ -488,42 +452,42 @@ public final class SessionEntityTypesGrpc {
     public void deleteSessionEntityType(
         com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteSessionEntityTypeMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteSessionEntityTypeMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListSessionEntityTypesMethodHelper(),
+              getListSessionEntityTypesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest,
                       com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>(
                       this, METHODID_LIST_SESSION_ENTITY_TYPES)))
           .addMethod(
-              getGetSessionEntityTypeMethodHelper(),
+              getGetSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.SessionEntityType>(
                       this, METHODID_GET_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getCreateSessionEntityTypeMethodHelper(),
+              getCreateSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.SessionEntityType>(
                       this, METHODID_CREATE_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getUpdateSessionEntityTypeMethodHelper(),
+              getUpdateSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest,
                       com.google.cloud.dialogflow.v2beta1.SessionEntityType>(
                       this, METHODID_UPDATE_SESSION_ENTITY_TYPE)))
           .addMethod(
-              getDeleteSessionEntityTypeMethodHelper(),
+              getDeleteSessionEntityTypeMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest,
@@ -553,11 +517,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesStub> {
-    private SessionEntityTypesStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<SessionEntityTypesStub> {
     private SessionEntityTypesStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -584,7 +544,7 @@ public final class SessionEntityTypesGrpc {
                 com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSessionEntityTypesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListSessionEntityTypesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -604,7 +564,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -626,7 +586,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -646,7 +606,7 @@ public final class SessionEntityTypesGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.SessionEntityType>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -665,7 +625,7 @@ public final class SessionEntityTypesGrpc {
         com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteSessionEntityTypeMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteSessionEntityTypeMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -692,11 +652,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesBlockingStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesBlockingStub> {
-    private SessionEntityTypesBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SessionEntityTypesBlockingStub> {
     private SessionEntityTypesBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -722,7 +678,7 @@ public final class SessionEntityTypesGrpc {
         listSessionEntityTypes(
             com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListSessionEntityTypesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListSessionEntityTypesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -738,7 +694,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2beta1.SessionEntityType getSessionEntityType(
         com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -756,7 +712,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2beta1.SessionEntityType createSessionEntityType(
         com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -772,7 +728,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.cloud.dialogflow.v2beta1.SessionEntityType updateSessionEntityType(
         com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateSessionEntityTypeMethod(), getCallOptions(), request);
     }
 
     /**
@@ -788,7 +744,7 @@ public final class SessionEntityTypesGrpc {
     public com.google.protobuf.Empty deleteSessionEntityType(
         com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteSessionEntityTypeMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteSessionEntityTypeMethod(), getCallOptions(), request);
     }
   }
 
@@ -813,11 +769,7 @@ public final class SessionEntityTypesGrpc {
    * </pre>
    */
   public static final class SessionEntityTypesFutureStub
-      extends io.grpc.stub.AbstractStub<SessionEntityTypesFutureStub> {
-    private SessionEntityTypesFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SessionEntityTypesFutureStub> {
     private SessionEntityTypesFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -843,7 +795,7 @@ public final class SessionEntityTypesGrpc {
         listSessionEntityTypes(
             com.google.cloud.dialogflow.v2beta1.ListSessionEntityTypesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListSessionEntityTypesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListSessionEntityTypesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -861,7 +813,7 @@ public final class SessionEntityTypesGrpc {
         getSessionEntityType(
             com.google.cloud.dialogflow.v2beta1.GetSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetSessionEntityTypeMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -881,8 +833,7 @@ public final class SessionEntityTypesGrpc {
         createSessionEntityType(
             com.google.cloud.dialogflow.v2beta1.CreateSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -900,8 +851,7 @@ public final class SessionEntityTypesGrpc {
         updateSessionEntityType(
             com.google.cloud.dialogflow.v2beta1.UpdateSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateSessionEntityTypeMethod(), getCallOptions()), request);
     }
 
     /**
@@ -918,8 +868,7 @@ public final class SessionEntityTypesGrpc {
         deleteSessionEntityType(
             com.google.cloud.dialogflow.v2beta1.DeleteSessionEntityTypeRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteSessionEntityTypeMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteSessionEntityTypeMethod(), getCallOptions()), request);
     }
   }
 
@@ -1040,11 +989,11 @@ public final class SessionEntityTypesGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SessionEntityTypesFileDescriptorSupplier())
-                      .addMethod(getListSessionEntityTypesMethodHelper())
-                      .addMethod(getGetSessionEntityTypeMethodHelper())
-                      .addMethod(getCreateSessionEntityTypeMethodHelper())
-                      .addMethod(getUpdateSessionEntityTypeMethodHelper())
-                      .addMethod(getDeleteSessionEntityTypeMethodHelper())
+                      .addMethod(getListSessionEntityTypesMethod())
+                      .addMethod(getGetSessionEntityTypeMethod())
+                      .addMethod(getCreateSessionEntityTypeMethod())
+                      .addMethod(getUpdateSessionEntityTypeMethod())
+                      .addMethod(getDeleteSessionEntityTypeMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/SessionsGrpc.java
+++ b/grpc-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/SessionsGrpc.java
@@ -36,7 +36,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dialogflow/v2beta1/session.proto")
 public final class SessionsGrpc {
 
@@ -45,30 +45,20 @@ public final class SessionsGrpc {
   public static final String SERVICE_NAME = "google.cloud.dialogflow.v2beta1.Sessions";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDetectIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
-      METHOD_DETECT_INTENT = getDetectIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
           com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
       getDetectIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DetectIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.DetectIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.DetectIntentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
           com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
       getDetectIntentMethod() {
-    return getDetectIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
-      getDetectIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
             com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
@@ -83,9 +73,7 @@ public final class SessionsGrpc {
                           com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Sessions", "DetectIntent"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DetectIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -103,30 +91,20 @@ public final class SessionsGrpc {
     return getDetectIntentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getStreamingDetectIntentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
-      METHOD_STREAMING_DETECT_INTENT = getStreamingDetectIntentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
           com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
       getStreamingDetectIntentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StreamingDetectIntent",
+      requestType = com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest.class,
+      responseType = com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
           com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
       getStreamingDetectIntentMethod() {
-    return getStreamingDetectIntentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
-          com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
-      getStreamingDetectIntentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
             com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
@@ -143,8 +121,7 @@ public final class SessionsGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dialogflow.v2beta1.Sessions", "StreamingDetectIntent"))
+                          generateFullMethodName(SERVICE_NAME, "StreamingDetectIntent"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,19 +142,42 @@ public final class SessionsGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SessionsStub newStub(io.grpc.Channel channel) {
-    return new SessionsStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsStub>() {
+          @java.lang.Override
+          public SessionsStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsStub(channel, callOptions);
+          }
+        };
+    return SessionsStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SessionsBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SessionsBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsBlockingStub>() {
+          @java.lang.Override
+          public SessionsBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsBlockingStub(channel, callOptions);
+          }
+        };
+    return SessionsBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SessionsFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SessionsFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SessionsFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SessionsFutureStub>() {
+          @java.lang.Override
+          public SessionsFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SessionsFutureStub(channel, callOptions);
+          }
+        };
+    return SessionsFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -206,7 +206,7 @@ public final class SessionsGrpc {
         com.google.cloud.dialogflow.v2beta1.DetectIntentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getDetectIntentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDetectIntentMethod(), responseObserver);
     }
 
     /**
@@ -224,22 +224,21 @@ public final class SessionsGrpc {
             io.grpc.stub.StreamObserver<
                     com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
                 responseObserver) {
-      return asyncUnimplementedStreamingCall(
-          getStreamingDetectIntentMethodHelper(), responseObserver);
+      return asyncUnimplementedStreamingCall(getStreamingDetectIntentMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getDetectIntentMethodHelper(),
+              getDetectIntentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.DetectIntentRequest,
                       com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>(
                       this, METHODID_DETECT_INTENT)))
           .addMethod(
-              getStreamingDetectIntentMethodHelper(),
+              getStreamingDetectIntentMethod(),
               asyncBidiStreamingCall(
                   new MethodHandlers<
                       com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentRequest,
@@ -259,11 +258,7 @@ public final class SessionsGrpc {
    * user intent and respond.
    * </pre>
    */
-  public static final class SessionsStub extends io.grpc.stub.AbstractStub<SessionsStub> {
-    private SessionsStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class SessionsStub extends io.grpc.stub.AbstractAsyncStub<SessionsStub> {
     private SessionsStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -288,7 +283,7 @@ public final class SessionsGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDetectIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDetectIntentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -309,7 +304,7 @@ public final class SessionsGrpc {
                     com.google.cloud.dialogflow.v2beta1.StreamingDetectIntentResponse>
                 responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingDetectIntentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getStreamingDetectIntentMethod(), getCallOptions()),
           responseObserver);
     }
   }
@@ -325,11 +320,7 @@ public final class SessionsGrpc {
    * </pre>
    */
   public static final class SessionsBlockingStub
-      extends io.grpc.stub.AbstractStub<SessionsBlockingStub> {
-    private SessionsBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SessionsBlockingStub> {
     private SessionsBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -351,8 +342,7 @@ public final class SessionsGrpc {
      */
     public com.google.cloud.dialogflow.v2beta1.DetectIntentResponse detectIntent(
         com.google.cloud.dialogflow.v2beta1.DetectIntentRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDetectIntentMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDetectIntentMethod(), getCallOptions(), request);
     }
   }
 
@@ -367,11 +357,7 @@ public final class SessionsGrpc {
    * </pre>
    */
   public static final class SessionsFutureStub
-      extends io.grpc.stub.AbstractStub<SessionsFutureStub> {
-    private SessionsFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SessionsFutureStub> {
     private SessionsFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -395,7 +381,7 @@ public final class SessionsGrpc {
             com.google.cloud.dialogflow.v2beta1.DetectIntentResponse>
         detectIntent(com.google.cloud.dialogflow.v2beta1.DetectIntentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDetectIntentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDetectIntentMethod(), getCallOptions()), request);
     }
   }
 
@@ -494,8 +480,8 @@ public final class SessionsGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SessionsFileDescriptorSupplier())
-                      .addMethod(getDetectIntentMethodHelper())
-                      .addMethod(getStreamingDetectIntentMethodHelper())
+                      .addMethod(getDetectIntentMethod())
+                      .addMethod(getStreamingDetectIntentMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,48 +14,17 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'dialogflow'
 versions = ['v2', 'v2beta1']
 config_pattern = '/google/cloud/dialogflow/{version}/artman_dialogflow_{version}.yaml'
 
-library = gapic.java_library(
-    service=service,
-    version='v2',
-    config_path='/google/cloud/dialogflow/v2/artman_dialogflow_v2.yaml',
-    artman_output_name='')
-
-package_name = f'com.google.cloud.{service}.v2'
-java.fix_proto_headers(library / f'proto-google-cloud-{service}-v2')
-java.fix_grpc_headers(library / f'grpc-google-cloud-{service}-v2', package_name)
-
-s.copy(library / f'gapic-google-cloud-{service}-v2/src', f'google-cloud-{service}/src')
-s.copy(library / f'grpc-google-cloud-{service}-v2/src', f'grpc-google-cloud-{service}-v2/src')
-s.copy(library / f'proto-google-cloud-{service}-v2/src', f'proto-google-cloud-{service}-v2/src')
-
-library = gapic.java_library(
-    service=service,
-    version='v2beta1',
-    config_path='/google/cloud/dialogflow/v2beta1/artman_dialogflow_v2beta1_java.yaml',
-    artman_output_name='')
-
-package_name = f'com.google.cloud.{service}.v2beta1'
-java.fix_proto_headers(library / f'proto-google-cloud-{service}-v2beta1')
-java.fix_grpc_headers(library / f'grpc-google-cloud-{service}-v2beta1', package_name)
-
-s.copy(library / f'gapic-google-cloud-{service}-v2beta1/src', f'google-cloud-{service}/src')
-s.copy(library / f'grpc-google-cloud-{service}-v2beta1/src', f'grpc-google-cloud-{service}-v2beta1/src')
-s.copy(library / f'proto-google-cloud-{service}-v2beta1/src', f'proto-google-cloud-{service}-v2beta1/src')
-
-
 for version in versions:
-  java.format_code(f'google-cloud-{service}/src')
-  java.format_code(f'grpc-google-cloud-{service}-{version}/src')
-  java.format_code(f'proto-google-cloud-{service}-{version}/src')
+  java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
+  )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

