### PR TITLE
fix: removes flaky intent equivalence assertion

### DIFF
--- a/google-cloud-dialogflow/src/test/java/com/google/cloud/dialogflow/v2/it/ITSystemTest.java
+++ b/google-cloud-dialogflow/src/test/java/com/google/cloud/dialogflow/v2/it/ITSystemTest.java
@@ -282,7 +282,6 @@ public class ITSystemTest {
     assertEquals(EVENT_NAME, result.getQueryText());
     assertEquals(ACTION_NAME, result.getAction());
     assertEquals(DEFAULT_LANGUAGE_CODE, result.getLanguageCode());
-    assertEquals(intent.getName(), result.getIntent().getName());
     assertEquals(intent.getDisplayName(), result.getIntent().getDisplayName());
   }
 

--- a/samples/snippets/src/main/java/com/example/dialogflow/UpdateIntent.java
+++ b/samples/snippets/src/main/java/com/example/dialogflow/UpdateIntent.java
@@ -24,7 +24,6 @@ import com.google.cloud.dialogflow.v2.UpdateIntentRequest;
 import com.google.protobuf.FieldMask;
 import java.io.IOException;
 
-
 public class UpdateIntent {
 
   public static void main(String[] args) throws IOException {
@@ -38,23 +37,15 @@ public class UpdateIntent {
 
   // DialogFlow API Update Intent sample.
   public static void updateIntent(
-      String projectId, String intentId, String location, String displayName)
-      throws IOException {
+      String projectId, String intentId, String location, String displayName) throws IOException {
     try (IntentsClient client = IntentsClient.create()) {
       String intentPath =
-          "projects/"
-              + projectId
-              + "/locations/"
-              + location
-              + "/agent/intents/"
-              + intentId;
+          "projects/" + projectId + "/locations/" + location + "/agent/intents/" + intentId;
 
       Builder intentBuilder = client.getIntent(intentPath).toBuilder();
 
       intentBuilder.setDisplayName(displayName);
-      FieldMask fieldMask = FieldMask.newBuilder()
-          .addPaths("display_name")
-          .build();
+      FieldMask fieldMask = FieldMask.newBuilder().addPaths("display_name").build();
 
       Intent intent = intentBuilder.build();
       UpdateIntentRequest request =

--- a/samples/snippets/src/test/java/com/example/dialogflow/UpdateIntentIT.java
+++ b/samples/snippets/src/test/java/com/example/dialogflow/UpdateIntentIT.java
@@ -18,10 +18,6 @@ package com.example.dialogflow;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.dialogflow.v2.Agent;
-import com.google.cloud.dialogflow.v2.Agent.Builder;
-import com.google.cloud.dialogflow.v2.AgentsClient;
-import com.google.cloud.dialogflow.v2.AgentsSettings;
 import com.google.cloud.dialogflow.v2.Intent;
 import com.google.cloud.dialogflow.v2.IntentsClient;
 import java.io.ByteArrayOutputStream;
@@ -64,11 +60,8 @@ public class UpdateIntentIT {
 
     IntentsClient client = IntentsClient.create();
 
-    String intentPath = 
-        "projects/"
-            + PROJECT_ID
-            + "/locations/global/agent/intents/"
-            + UpdateIntentIT.intentID;
+    String intentPath =
+        "projects/" + PROJECT_ID + "/locations/global/agent/intents/" + UpdateIntentIT.intentID;
 
     client.deleteIntent(intentPath);
   }
@@ -78,8 +71,7 @@ public class UpdateIntentIT {
 
     String fakeIntent = "fake_intent_" + UUID.randomUUID().toString();
 
-    UpdateIntent.updateIntent(
-        PROJECT_ID, UpdateIntentIT.intentID, "global", fakeIntent);
+    UpdateIntent.updateIntent(PROJECT_ID, UpdateIntentIT.intentID, "global", fakeIntent);
 
     assertThat(stdOut.toString()).contains(fakeIntent);
   }


### PR DESCRIPTION
Because of how intents work in Dialogflow, asserting that the actual name of a resource matches the name of a newly created resource will not always be deterministic, especially if duplicate intents are added. This PR removes the offending assertion.

Fixes #623  ☕️
